### PR TITLE
Fix #7: Improve HttpError string output

### DIFF
--- a/docs/teamdynamix/exceptions.md
+++ b/docs/teamdynamix/exceptions.md
@@ -72,6 +72,9 @@ You typically do not instantiate exceptions directly (except in tests). They are
 
 - `HttpError` is raised when a response returns a **non-success status code**.
 - The error is intended to be actionable: method + URL + status + any available body.
+- Converting the exception to a string returns its explicit `message`, when set,
+  or a concise `HTTP <status> <method> <URL>` summary. The response body is not
+  included automatically, which avoids leaking sensitive API details into logs.
 
 ------
 

--- a/src/teamdynamix/exceptions.py
+++ b/src/teamdynamix/exceptions.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 
 class TdxError(Exception):
@@ -27,6 +26,10 @@ class HttpError(TdxError):
     url: str
     message: str = ""
     response_text: str = ""
+
+    def __str__(self) -> str:
+        """Return a concise, response-body-free description of the failure."""
+        return self.message or f"HTTP {self.status_code} {self.method.upper()} {self.url}"
 
 
 class TdxTimeoutError(TdxError):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,27 @@
+from teamdynamix.exceptions import HttpError, TdxError
+
+
+def test_http_error_formats_request_context_without_response_body() -> None:
+    error = HttpError(
+        status_code=403,
+        method="post",
+        url="https://example.teamdynamix.com/api/projects/36/resources/abc",
+        response_text="sensitive response details",
+    )
+
+    assert str(error) == (
+        "HTTP 403 POST https://example.teamdynamix.com/api/projects/36/resources/abc"
+    )
+    assert "sensitive" not in str(error)
+
+
+def test_http_error_preserves_explicit_message_and_exception_hierarchy() -> None:
+    error = HttpError(
+        status_code=404,
+        method="GET",
+        url="https://example.teamdynamix.com/api/items/1",
+        message="Item was not found",
+    )
+
+    assert str(error) == "Item was not found"
+    assert isinstance(error, TdxError)


### PR DESCRIPTION
Implements #7.

- Adds a concise, response-body-free HttpError.__str__()
- Preserves explicit error messages
- Adds focused unit tests and exception documentation

Validation: pytest tests/test_exceptions.py --no-cov; Ruff.