### PR TITLE
Fix #15: Forward log name prefixes through Session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# teamdynamix-api
+
+An experimental Python SDK for the TeamDynamix Web API. The project keeps
+authentication, transport, configuration, and logging in a shared `Session`
+while exposing endpoint-oriented client modules.
+
+> **Pre-alpha:** APIs may change between releases. The `pre-alpha/11` release
+> is the final baseline derived from the legacy TeamDynamix/Postman corpus;
+> Swagger/OpenAPI realignment is planned for `pre-alpha/12`.
+
+## Installation
+
+Install the project from a local checkout:
+
+```bash
+python -m pip install .
+```
+
+Python 3.10 or newer is required.
+
+## Session logging
+
+`Session` uses `log-<timestamp>.txt` by default. Scripts can provide a
+descriptive prefix so their log files are easy to distinguish:
+
+```python
+from teamdynamix import Session
+
+session = Session("./config/config.ini", name_prefix="log-mytool")
+```
+
+This produces a filename such as `log-mytool-20260825153000.txt` in the
+configured log directory.
+
+See [the documentation index](docs/INDEX.md) for architecture, configuration,
+client, and contributor documentation.

--- a/docs/teamdynamix/logger.md
+++ b/docs/teamdynamix/logger.md
@@ -48,6 +48,7 @@ logger = Logger(
     log_dir="./logs",
     level="INFO",
     console=True,
+    name_prefix="log-mytool",
 )
 ```
 
@@ -55,6 +56,10 @@ Instantiation creates:
 
 - A log directory (if it does not exist)
 - A timestamped log file within that directory
+
+The `name_prefix` parameter controls the text before the timestamp. It defaults
+to `"log"`, preserving filenames such as `log-20260825153000.txt`. A script can
+use a descriptive value such as `"log-mytool"` to make its output identifiable.
 
 No I/O occurs beyond directory creation.
 

--- a/docs/teamdynamix/session.md
+++ b/docs/teamdynamix/session.md
@@ -65,17 +65,31 @@ Session(
     auth_mode: Literal["admin", "user"] | None = None,
     environment: Literal["TD", "SBTD"] | None = None,
     overrides: Mapping[str, Any] | None = None,
+    name_prefix: str | None = None,
 )
 ```
 
 ### Parameters
 
-| Name          | Type                                | Description                   |
-| ------------- | ----------------------------------- | ----------------------------- |
-| `config`      | path \| `Config` | mapping | `None` | Base configuration source     |
-| `auth_mode`   | `"admin"` | `"user"` | `None`       | Explicit auth mode override   |
-| `environment` | `"TD"` | `"SBTD"` | `None`          | Explicit environment override |
-| `overrides`   | `Mapping[str, Any] | None`          | Late-applied config overrides |
+| Name          | Type                               | Description                                      |
+| ------------- | ---------------------------------- | ------------------------------------------------ |
+| `config`      | `ConfigSource`                     | Base configuration source                        |
+| `auth_mode`   | `AuthMode | None`                  | Explicit auth mode override                      |
+| `environment` | `TdxEnvironment | None`            | Explicit environment override                    |
+| `overrides`   | `Mapping[str, Any] | None`         | Late-applied config overrides                    |
+| `name_prefix` | `str | None`                       | Log filename prefix; defaults to `"log"`        |
+
+To identify the log files created by a particular script, provide a prefix at
+construction time:
+
+```python
+from teamdynamix import Session
+
+session = Session("./config/config.ini", name_prefix="log-mytool")
+```
+
+The session forwards the value to its `Logger`, producing filenames such as
+`log-mytool-20260825153000.txt`.
 
 ------
 
@@ -175,6 +189,7 @@ self.logger = Logger(
     log_dir=self.config.log_dir,
     level=self.config.log_level,
     console=self.config.log_console,
+    name_prefix=name_prefix or "log",
 )
 ```
 

--- a/src/teamdynamix/logger.py
+++ b/src/teamdynamix/logger.py
@@ -3,13 +3,11 @@
 # =====================================================================
 from __future__ import annotations
 
-from pathlib import Path
-from typing import List, Optional
 import threading
 import time
+from pathlib import Path
 
 from .event import Event
-
 
 _LEVELS = {
     "CRITICAL": 50,
@@ -25,7 +23,7 @@ class Logger:
     """
     Minimal logger:
     - Keeps an in-memory list of Event objects
-    - Writes to a timestamped file under log_dir
+    - Writes to a ``<name_prefix>-<timestamp>.txt`` file under log_dir
     - Prints to console (optional)
     - Default level behavior: ERROR (catches errors/exceptions, ignores warnings)
     """
@@ -35,9 +33,9 @@ class Logger:
         level: str = "ERROR",
         console: bool = True,
         name_prefix: str = "log",
-    ):
+    ) -> None:
         self._lock = threading.RLock()
-        self.events: List[Event] = []
+        self.events: list[Event] = []
 
         self.level_name = (level or "ERROR").strip().upper()
         self.level = _LEVELS.get(self.level_name, 40)
@@ -49,7 +47,7 @@ class Logger:
         self.log_file = self.log_dir / f"{name_prefix}-{ts}.txt"
         self.console = bool(console)
 
-    def log(self, message: str, level: int | None = None, context: Optional[dict] = None) -> None:
+    def log(self, message: str, level: int | None = None, context: dict | None = None) -> None:
         lvl = self.level if level is None else int(level)
 
         # Filter: only record if lvl >= configured level

--- a/src/teamdynamix/session.py
+++ b/src/teamdynamix/session.py
@@ -3,19 +3,19 @@
 # =====================================================================
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Dict, Optional, Union, Literal, Mapping
+from typing import Any, Literal
 
 from .auth import Auth
-from .config import Config, AuthMode
+from .config import AuthMode, Config
+from .exceptions import ConfigError
 from .logger import Logger
 from .transport import Transport
-from .exceptions import ConfigError
-
 
 TdxEnvironment = Literal["TD", "SBTD"]
-ConfigSource = Union[str, Path, Config, Mapping[str, Any], None]
+ConfigSource = str | Path | Config | Mapping[str, Any] | None
 
 
 class Session:
@@ -26,19 +26,21 @@ class Session:
       - config may be: path | Config | dict-like overlay | None
       - overrides may be: dict of key-value pairs applied after base config
       - auth_mode/environment can be overridden explicitly (validated literals)
+      - name_prefix customizes the session log filename prefix
     """
 
     def __init__(
         self,
         config: ConfigSource = "./config/config.ini",
         *,
-        auth_mode: Optional[AuthMode] = None,
-        environment: Optional[TdxEnvironment] = None,
-        overrides: Optional[Mapping[str, Any]] = None,
-    ):
+        auth_mode: AuthMode | None = None,
+        environment: TdxEnvironment | None = None,
+        overrides: Mapping[str, Any] | None = None,
+        name_prefix: str | None = None,
+    ) -> None:
         # 1) Resolve base config
-        base_cfg: Optional[Config] = None
-        overlay: Dict[str, Any] = {}
+        base_cfg: Config | None = None
+        overlay: dict[str, Any] = {}
 
         if config is None:
             # default behavior: load from default ini path
@@ -56,7 +58,7 @@ class Session:
 
         # 2) Merge overlays in correct precedence order:
         #    base_cfg < config-mapping (if provided) < overrides < explicit keyword overrides
-        merged: Dict[str, Any] = {}
+        merged: dict[str, Any] = {}
         if base_cfg is not None:
             merged.update(asdict(base_cfg))
 
@@ -79,7 +81,7 @@ class Session:
         # 3) Build Config once (single validation point)
         #    ConfigError should only occur here if required fields remain missing/invalid.
         try:
-            self.config = Config(**merged)  # type: ignore[arg-type]
+            self.config = Config(**merged)
         except TypeError as e:
             # Common cause: unknown key in overrides dict
             raise ConfigError(f"Invalid configuration keys provided: {e}") from e
@@ -89,6 +91,7 @@ class Session:
             log_dir=self.config.log_dir,
             level=self.config.log_level,
             console=self.config.log_console,
+            name_prefix=name_prefix or "log",
         )
 
         self.transport = Transport(
@@ -118,7 +121,7 @@ class Session:
         """
         return self.auth.authenticate()
 
-    def auth_header(self) -> Dict[str, str]:
+    def auth_header(self) -> dict[str, str]:
         token = self.auth.get_token()
         return {"Authorization": f"Bearer {token}"}
 

--- a/tests/test_logger_session.py
+++ b/tests/test_logger_session.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from teamdynamix import Config, Logger, Session
+
+
+def _config(log_dir: Path) -> Config:
+    return Config(
+        tenant="example.teamdynamix.com",
+        environment="TD",
+        beid="example-beid",
+        webserviceskey="example-key",
+        log_dir=str(log_dir),
+        log_console=False,
+    )
+
+
+def test_logger_uses_default_name_prefix(tmp_path: Path) -> None:
+    logger = Logger(log_dir=tmp_path, console=False)
+
+    assert logger.log_file.parent == tmp_path
+    assert logger.log_file.name.startswith("log-")
+    assert logger.log_file.suffix == ".txt"
+
+
+def test_session_forwards_custom_name_prefix(tmp_path: Path) -> None:
+    session = Session(_config(tmp_path), name_prefix="log-mytool")
+
+    assert session.logger.log_file.name.startswith("log-mytool-")
+    session.log("session initialized")
+    assert session.logger.log_file.exists()
+
+
+def test_session_without_name_prefix_preserves_default(tmp_path: Path) -> None:
+    session = Session(_config(tmp_path))
+
+    assert session.logger.log_file.name.startswith("log-")


### PR DESCRIPTION
Implements #15.

- Adds the optional Session name_prefix parameter and forwards it to Logger
- Preserves the default log prefix
- Documents direct Logger and Session usage, including the new project README
- Adds focused, credential-free tests

Validation: 5 focused pytest tests; Ruff; mypy.