### PR TITLE
Advance #16: Stabilize the pre-alpha/11 release corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ venv/
 .pytest_cache/
 .mypy_cache/
 coverage.xml
+.coverage
 htmlcov/
 logs/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,236 +1,60 @@
-# CHANGELOG.md
+# Changelog
 
-All notable changes to the **TeamDynamix API Python SDK** are documented in this file.
+All notable changes to the TeamDynamix API Python SDK are documented here.
+Pre-alpha releases are experimental snapshots and may contain breaking changes.
 
-This project follows **reverse-chronological pre-alpha versioning**.
-Breaking changes *may* occur between pre-alpha releases.
+## [0.0.0-pre-alpha.11] - 2026-08-25
 
----
+Python distribution metadata uses the PEP 440 equivalent `0.0.0a11`.
 
-## [pre-alpha0x] — Initial Experimental Foundation
+### Added
 
-**Focus:** Exploration and architectural discovery
+- Attribute-choice list, create/copy, edit, and delete operations.
+- Custom-attribute discovery with optional component, associated-type, and
+  application filters.
+- `AttributeChoice` and raw/typed Attributes response patterns.
+- `teamdynamix.tools` CSV and SQLite helpers for local automation scripts.
+- Script-specific logger filename prefixes exposed through `Session`.
+- README, MIT license, PEP 561 marker, deterministic core tests, and built-wheel
+  import smoke tests.
 
-### Characteristics
+### Changed
 
-* Early API client experiments
-* Mixed patterns and approaches
-* Limited documentation
-* Inconsistent abstractions
-* No formal release discipline
+- Declared pandas as a runtime dependency because importing
+  `teamdynamix.tools` imports its pandas-backed CSV implementation.
+- Reclassified live, state-changing endpoint scripts as manual examples.
+- Corrected package project URLs to GitHub and aligned release branch guidance
+  with the project promotion model.
+- Set an honest 35% coverage floor; the release suite currently exceeds it.
 
-### Outcome
+### Fixed
 
-* Served as the proving ground for:
+- `HttpError` now renders useful HTTP request context while omitting response
+  text from its default string form.
+- Core documentation links and Attributes method names now resolve to the
+  implemented surface.
+- The `py.typed` marker is now located and packaged under `teamdynamix`.
 
-  * Session/Transport split
-  * Lazy authentication
-  * Minimal DTO philosophy
-* Fully consolidated and retired prior to `pre-alpha10`
+### Historical boundary
 
----
+This release is the final baseline derived from the legacy TeamDynamix Postman
+corpus. Swagger/OpenAPI realignment begins in Pre-Alpha 12.
 
-## Versioning Notes
+## [0.0.0-pre-alpha.10]
 
-* Pre-alpha releases prioritize learning and structure over stability
-* Backward compatibility is **not guaranteed**
-* Breaking changes are documented explicitly when they occur
+### Added
 
----
+- Consolidated the Session, Transport, Auth, Config, and logging architecture.
+- Added or expanded People, Groups, Accounts, Applications, Functional Roles,
+  Tickets, Projects, and Service Catalog clients.
+- Added structured logging events and centralized JSON Patch normalization.
 
-## [pre-alpha10] — Structural Consolidation & API Surface Growth
+### Changed
 
-**Focus:** Architectural clarity, core API coverage, internal consistency
+- Standardized thin, endpoint-oriented clients and selective dataclass DTOs.
+- Consolidated earlier experimental branches into a documented baseline.
 
-### Major Changes
+## [pre-alpha0x]
 
-* Consolidated all legacy and experimental work into a clean baseline
-* Formalized architectural decisions:
-
-  * Session as composition root
-  * Transport as sole HTTP boundary
-  * Centralized JSON Patch handling
-* Introduced consistent DTO patterns across modules
-* Added or expanded clients:
-
-  * People
-  * Groups
-  * Accounts
-  * Applications
-  * Functional Roles
-  * Tickets
-  * Projects
-* Established consistent logging and exception strategy
-* Introduced `Event` model for structured logging
-
-### Documentation
-
-* Added `Architectural_Decisions.md`
-* Improved module-level docstrings across core and client modules
-
----
-
-## [Unreleased] — Pre-Alpha 11 (WIP → Final)
-
-**Focus:** Documentation maturity, Attributes API parity, script-oriented tooling
-
-### Core Architecture & Infrastructure
-
-* No breaking architectural changes.
-* Session remains the composition root.
-* Transport remains the single HTTP boundary.
-* Auth remains lazily evaluated and thread-safe.
-
----
-
-### Attributes API — Major Expansion (Issue #5)
-
-**New capabilities added to `src/teamdynamix/attributes.py`:**
-
-* Added full support for **Attribute Choices**:
-
-  * `GET /api/attributes/{id}/choices`
-  * `POST /api/attributes/{id}/choices`
-
-    * Supports `copyFromChoiceId`
-  * `PUT /api/attributes/{id}/choices/{choiceId}`
-  * `DELETE /api/attributes/{id}/choices/{choiceId}`
-
-* Added support for **Custom Attributes**:
-
-  * `GET /api/attributes/custom`
-  * Optional filters:
-
-    * `componentId`
-    * `associatedTypeId`
-    * `appId`
-
-* Introduced **dual-method pattern**:
-
-  * Raw methods returning `Dict[str, Any]` / `List[Dict[str, Any]]`
-  * Typed wrapper methods returning DTOs
-
-* Added new `AttributeChoice` DTO aligned with observed API schema:
-
-  * ID
-  * Name
-  * IsActive
-  * DateCreated
-  * DateModified
-  * Order
-
-**Result:**
-The Attributes client now reaches practical parity with the TeamDynamix Web API and Postman collection.
-
----
-
-### New Sub-Package: `teamdynamix.tools`
-
-Introduced a dedicated namespace for **script-oriented utilities** that are intentionally *not* API clients.
-
-Design principles:
-
-* No HTTP calls
-* No dependency on client modules
-* Safe for one-off scripts
-* Explicit, predictable behavior
-
----
-
-### CSV Utilities (`csv_utils.py`)
-
-**Purpose:** Safe, unopinionated CSV ingestion for scripts and automation.
-
-Key features:
-
-* Load any CSV file into a searchable table object
-* Supports arbitrary column counts
-* Global default delimiter (ASCII code–based)
-* Runtime override via `set_separator()`
-* Pandas-backed for robustness
-
-Supported operations:
-
-* Load full CSV into memory
-* Row count / column count
-* Retrieve row by index
-* Retrieve cell by row/column
-* Retrieve all values in a column
-* Case-sensitive and insensitive search:
-
-  * `search_contains`
-  * `search_exact`
-* Structured search results via `CellMatch` objects
-
-  * `.row` / `.column` / `.value`
-  * `.x` / `.y` aliases for ergonomic access
-
-All operations are **read-only by design**.
-
----
-
-### SQLite Utilities (`sqlite_utils.py`)
-
-**Purpose:** Lightweight, temporary SQLite tracking for long-running or restartable scripts.
-
-Primary use cases:
-
-* CSV-driven imports
-* API batch processing
-* SQL query result iteration
-* Error capture and replay
-
-Key capabilities:
-
-* Create or reuse SQLite database files
-* Automatic backup and archive support
-* Standard schema enforced:
-
-  * `data` table with `processed` flag
-  * `errors` table mirroring source columns + `error_msg`
-
-Row-processing workflow:
-
-* `pop()` retrieves the next unprocessed row
-* `mark_as_processed()` updates state
-* `write_error()` records failures while preserving original row data
-
-Query helpers:
-
-* Row count / column count
-* Column name ↔ index resolution
-* Retrieve rows or cells
-* Column value extraction
-* Search helpers:
-
-  * `search_contains`
-  * `search_exact`
-  * Row-index variants for control-flow usage
-
-Explicitly **not** an ORM and **not** intended for long-term persistence.
-
----
-
-### Documentation Improvements
-
-* Adopted **documentation as a first-class artifact**
-* Added full docs for:
-
-  * `csv_utils`
-  * `sqlite_utils`
-* Introduced tools README
-* Documentation aligns with:
-
-  * Module intent
-  * Public API surface
-  * Script usage patterns
-* Prepared groundwork for a docs index (`docs/INDEX.md`)
-* Planned addition of a documentation completeness checklist in `CONTRIBUTING.md`
-
----
-
-### Known Gaps (Accepted for Pre-Alpha)
-
-* Unit test coverage for new Attributes endpoints is limited
-* Some tooling behaviors intentionally trade type fidelity for predictability
-* Release metadata (version string, VERSION.md) pending final update
+- Established the initial experimental API clients and architectural proving
+  ground that preceded the numbered pre-alpha releases.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 University of Florida
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ python -m pip install .
 
 Python 3.10 or newer is required.
 
+The release label and Git tag are `0.0.0-pre-alpha.11`. Python distribution
+metadata uses the PEP 440 equivalent `0.0.0a11`, which is also exposed as
+`teamdynamix.__version__`.
+
 ## Session logging
 
 `Session` uses `log-<timestamp>.txt` by default. Scripts can provide a
@@ -34,3 +38,7 @@ configured log directory.
 
 See [the documentation index](docs/INDEX.md) for architecture, configuration,
 client, and contributor documentation.
+
+## License
+
+This project is available under the [MIT License](LICENSE).

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,97 +1,60 @@
-# VERSION.md
+# Pre-Alpha 11
 
-## Pre-Alpha 11 (`pre-alpha11`)
+- Release label and Git tag: `0.0.0-pre-alpha.11`
+- Python distribution version: `0.0.0a11`
+- Release type: Pre-alpha feature snapshot
+- Release date: 2026-08-25
 
-**Release Type:** Pre-Alpha
-**Audience:** SDK contributors, internal integrators, advanced script authors
-**Stability:** Experimental (no backward-compatibility guarantees)
+Python package indexes require PEP 440 versions. The distribution therefore
+uses `0.0.0a11`, the installable equivalent of the project’s SemVer release
+label `0.0.0-pre-alpha.11`.
 
----
+## Release identity
 
-### API Clients & Core Functionality
+Pre-Alpha 11 is the final SDK baseline derived from the legacy TeamDynamix
+Postman corpus. It does not claim conformance with the subsequently published
+Swagger/OpenAPI specification. OpenAPI path, operation, and schema alignment is
+planned for Pre-Alpha 12.
 
-* Expanded `Attributes` client to support full **Attribute Choices** lifecycle:
+## Highlights
 
-  * List, create (with optional copy), update, and delete attribute choices
-* Added support for **Custom Attribute** discovery via `/api/attributes/custom`
+- Expanded the `Attributes` client with attribute-choice lifecycle operations,
+  custom-attribute discovery, raw response methods, and typed wrappers.
+- Added the first `teamdynamix.tools` package with pandas-backed CSV helpers and
+  SQLite tracking utilities for local scripts.
+- Preserved the established `Session` / `Transport` / `Auth` architecture and
+  centralized JSON Patch handling.
+- Added concise `HttpError` string output without automatically exposing
+  response bodies.
+- Added script-specific logger filename prefixes through `Session`.
 
-  * Optional filtering by component, associated type, and application
-* Introduced `AttributeChoice` DTO aligned with observed TeamDynamix API schema
-* Preserved minimal, vendor-surface-aligned DTO philosophy for all attribute models
-* Maintained existing Session / Transport / Auth architecture without breaking changes
+## Release stabilization
 
----
+- Added deterministic tests for Session, Transport, Auth, Attributes, logging,
+  exceptions, and distribution artifacts; no live tenant credentials are
+  required.
+- Reclassified state-changing endpoint exercises as manual examples.
+- Added build/install smoke coverage for both `teamdynamix` and
+  `teamdynamix.tools`.
+- Declared pandas as a runtime dependency so the public tools package imports
+  from a normal installation.
+- Added README and MIT license files, corrected project URLs, and packaged the
+  PEP 561 `py.typed` marker in the library namespace.
+- Reconciled documentation links, method names, branch flow, and the historical
+  Postman/OpenAPI boundary.
 
-### New Script-Oriented Utilities (`teamdynamix.tools`)
+## Known limitations
 
-* Introduced `teamdynamix.tools` subpackage for non-API helper utilities
-* Explicitly decoupled tools from:
+- API coverage remains intentionally limited to modules already present in the
+  repository.
+- The `teamdynamix.tools` implementation is useful but has correctness,
+  scalability, state-model, and packaging boundaries scheduled for redesign in
+  Pre-Alpha 12.
+- Several existing client modules have only import-level or incidental test
+  coverage; the configured 35% project floor records the current baseline
+  rather than overstating maturity.
 
-  * HTTP transport
-  * API clients
-  * SDK workflows
+## Compatibility
 
-#### CSV Utilities
-
-* Added `csv_utils.py` for safe, unopinionated CSV ingestion
-* Supports arbitrary column counts and schemas
-* Global default delimiter defined via ASCII character code (default: comma)
-* Runtime delimiter override supported via setter (script-scoped)
-* Pandas-backed parsing for robustness and performance
-* Read-only operations including:
-
-  * Row and column access
-  * Column value extraction
-  * Cell-level access
-  * Case-sensitive and insensitive searching
-* Introduced `CellMatch` result object for structured search results
-
-#### SQLite Utilities
-
-* Added `sqlite_utils.py` for temporary, script-lifetime SQLite tracking
-* Supports creation, backup, and archival of SQLite database files
-* Enforces standard schema:
-
-  * `data` table with `processed` flag
-  * `errors` table mirroring source columns plus `error_msg`
-* Designed for restartable, row-by-row processing workflows
-* Provides helpers for:
-
-  * Row, column, and cell access
-  * Column name/index resolution
-  * Value searching (exact and contains)
-  * Error recording independent of processing state
-* Explicitly not an ORM and not intended for long-term persistence
-
----
-
-### Documentation
-
-* Formalized documentation as a first-class release artifact
-* Added full developer documentation for:
-
-  * `csv_utils`
-  * `sqlite_utils`
-* Introduced `docs/teamdynamix/tools/README.md`
-* Established and locked a reusable “JavaDocs-style” module documentation template
-* Updated architecture and module docs to align with current SDK design
-* Prepared groundwork for:
-
-  * Central docs index (`docs/INDEX.md`)
-  * Documentation completeness checklist in `CONTRIBUTING.md`
-
----
-
-### Known Limitations (Accepted for Pre-Alpha)
-
-* Unit test coverage for new Attributes endpoints is limited
-* Script utilities prioritize predictability over strict type preservation
-* Release metadata updates (version string sync) pending final tagging
-
----
-
-### Compatibility Notes
-
-* This release is additive but **not guaranteed backward-compatible**
-* APIs, DTOs, and helper utilities may change without notice
-* Intended for early adopters, internal tooling, and feedback-driven iteration
+This is an experimental snapshot with no backward-compatibility guarantee.
+Python 3.10 or newer is required.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,10 +37,14 @@ These documents define **non-negotiable constraints**.
 
 ### Long-Lived Branches
 
-| Branch    | Purpose                              |
-| --------- | ------------------------------------ |
-| `main`    | Latest stable or tagged pre-release  |
-| `develop` | Integration branch for upcoming work |
+| Branch | Purpose                                                    |
+| ------ | ---------------------------------------------------------- |
+| `main` | Latest stable or tagged pre-release                        |
+| `dev`  | Downstream-only integration and personal validation branch |
+
+`dev` is branched from `main`. Release snapshots may be pushed down to `dev`
+for intermediate testing, but `dev` is never merged upward into a release
+branch or `main`.
 
 ---
 
@@ -52,8 +56,9 @@ pre-alpha/N
 
 - Used only during Pre-Alpha phase
 - Tagged as `0.0.0-pre-alpha.N`
-- May be rebased or force-pushed
-- Typically merged once, then deleted
+- Acts as the release/integration branch for that pre-alpha corpus
+- Receives issue-scoped pull requests from short-lived feature or bugfix branches
+- Is promoted to `main` only after the full release checklist is complete
 
 ---
 
@@ -61,10 +66,12 @@ pre-alpha/N
 
 feature/
 
-- Branched from `develop`
+- Branched from `main` or the owning release branch when earlier release work is
+  a required dependency
 - Used for new functionality
 - Must not be tagged
-- Merged via pull request
+- Promoted into the owning release branch via pull request
+- Never merges directly to `main` as a substitute for the complete release
 
 ---
 
@@ -73,8 +80,8 @@ feature/
 bugfix/
 
 - Used for non-urgent fixes
-- Branched from `develop` or release branches
-- Merged back to origin branch
+- Branched from `main` or the release branch that owns the issue
+- Promoted into the owning release branch
 
 ---
 
@@ -82,7 +89,8 @@ bugfix/
 
 release/x.y.z
 
-- Branched from `develop`
+- Reserved for Alpha and later release stabilization when deliberately adopted
+- Branched from `main`
 - Used to stabilize a version
 - Tagged sequentially as:
   - `x.y.z-alpha`
@@ -98,7 +106,8 @@ hotfix/x.y.z
 
 - Branched from `main`
 - Used for urgent production fixes
-- Merged into both `main` and `develop`
+- Promoted according to the release process; any downstream copies are refreshed
+  from the corrected upstream branch
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,6 +2,11 @@
 
 This directory is the documentation home for the **TeamDynamix API Python SDK**.
 
+These pages describe the `pre-alpha/11` implementation: the final baseline
+derived from the legacy TeamDynamix Postman corpus. They do not claim alignment
+with the subsequently published Swagger/OpenAPI specification; that work is
+scheduled for `pre-alpha/12`.
+
 - Core philosophy: Session is the facade, Transport is the HTTP boundary, client modules are thin endpoint wrappers.
 - Docs style: “JavaDocs-style” module pages under `docs/teamdynamix/`.
 
@@ -9,9 +14,9 @@ This directory is the documentation home for the **TeamDynamix API Python SDK**.
 
 ## Core Architecture & Concepts
 
-- [Architecture](teamdynamix/ARCHITECTURE.md)
-- [Design](teamdynamix/DESIGN.md)
-- [Patterns](teamdynamix/PATTERNS.md)
+- [Architecture](ARCHITECTURE.md)
+- [Design](DESIGN.md)
+- [Patterns](PATTERNS.md)
 
 ---
 
@@ -37,8 +42,8 @@ This directory is the documentation home for the **TeamDynamix API Python SDK**.
 - [`applications`](teamdynamix/applications.md)
   - `Applications.list(...)`, `Applications.get(...)`
 - [`attributes`](teamdynamix/attributes.md)
-  - Attribute choices: `list_choices`, `create_choice`, `edit_choice`, `delete_choice`
-  - Custom attributes: `custom(...)`
+  - Attribute choices: `list_choices(...)`, `add_choice(...)`, `edit_choice(...)`, `delete_choice(...)`
+  - Custom attributes: `list_custom(...)`
 - [`people`](teamdynamix/people.md)
   - `People.get(...)`, `People.get_raw(...)`, `People.search(...)`, `People.user_list(...)`, `People.create(...)`, `People.update(...)`
   - Functional roles: `list_functional_roles(...)`, `add_functional_role(...)`, `remove_functional_role(...)`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -125,9 +125,14 @@ Update **only** if the corresponding module changed:
 ### Pre-Alpha Releases
 
 - [ ] Ensure work is on `pre-alpha/N` branch
+- [ ] Promote each completed feature branch into `pre-alpha/N` through its own pull request
 - [ ] Ensure branch represents a **feature-complete snapshot**
 - [ ] Merge `pre-alpha/N` → `main` (fast-forward preferred)
 - [ ] Delete branch after merge (optional)
+
+If intermediate integration testing is needed, a release snapshot may be
+pushed down to `dev`. The `dev` branch begins from `main` and is never merged
+upward into a release branch or `main`.
 
 ### Alpha and Later Releases
 

--- a/docs/teamdynamix/attributes.md
+++ b/docs/teamdynamix/attributes.md
@@ -69,7 +69,9 @@ Use raw methods when full payload access is required.
 
 A typed representation of an **attribute choice** (selectable option for an attribute).
 
-Fields align with the TeamDynamix API schema as exposed in the Postman collection.
+Fields align with the legacy TeamDynamix schema observed in the Postman
+collection used for the `pre-alpha/11` corpus. OpenAPI verification is deferred
+to `pre-alpha/12`.
 
 #### Fields
 

--- a/examples/live/README.md
+++ b/examples/live/README.md
@@ -1,0 +1,16 @@
+# Live endpoint exercises
+
+These scripts perform real, state-changing operations against a configured
+TeamDynamix tenant. They are manual examples, not automated tests, and pytest
+does not collect or run them.
+
+Before running one, create a tenant-specific configuration file from
+`config/sample.config.ini`, review every hard-coded identifier and payload, and
+use a sandbox tenant with disposable data.
+
+```bash
+python examples/live/people_endpoints.py
+python examples/live/ticket_endpoints.py
+```
+
+Never commit credentials or tenant configuration files.

--- a/examples/live/people_endpoints.py
+++ b/examples/live/people_endpoints.py
@@ -1,7 +1,7 @@
 # =====================================================================
-# FILE: test_people_endpoints.py
+# FILE: examples/live/people_endpoints.py
 #
-# Minimal endpoint test script for People API client.
+# Manual live-endpoint exercise for the People API client.
 # - Assumes your config is valid at ./config/sandbox.config.ini (adjust as needed).
 # - Uses the library as currently implemented: Session + People + Person.
 # =====================================================================

--- a/examples/live/ticket_endpoints.py
+++ b/examples/live/ticket_endpoints.py
@@ -1,7 +1,7 @@
 # =====================================================================
-# FILE: tests/test_ticket_endpoints.py
+# FILE: examples/live/ticket_endpoints.py
 #
-# Minimal endpoint test script for Tickets API client.
+# Manual live-endpoint exercise for the Tickets API client.
 # - Assumes your config is valid at ./config/sandbox.config.ini (adjust as needed).
 # - Assumes you have implemented: Tickets, TicketPriorities, TicketStatuses, TicketSources, TicketTypes.
 # - Assumes PATCH JSON Patch handling is centralized in Transport (dict -> JSON Patch list).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "teamdynamix-api"
-version = "0.1.0"
+version = "0.0.0a11"
 description = "A Python SDK for the TeamDynamix Web API."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -25,6 +25,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
+  "pandas>=2.0",
   "requests>=2.31",
 ]
 
@@ -35,13 +36,15 @@ dev = [
   "ruff>=0.5",
   "mypy>=1.10",
   "build>=1.2",
+  "setuptools>=68",
   "twine>=5.0",
+  "wheel",
 ]
 
 [project.urls]
-Homepage = "https://gitlab.it.ufl.edu/nicholas.linney/teamdynamix-api"
-Repository = "https://gitlab.it.ufl.edu/nicholas.linney/teamdynamix-api"
-"Issue Tracker" = "https://gitlab.it.ufl.edu/nicholas.linney/teamdynamix-api/-/issues"
+Homepage = "https://github.com/NicholasLinneyUF/teamdynamix-api"
+Repository = "https://github.com/NicholasLinneyUF/teamdynamix-api"
+"Issue Tracker" = "https://github.com/NicholasLinneyUF/teamdynamix-api/issues"
 
 [tool.setuptools]
 package-dir = { "" = "src" }
@@ -56,6 +59,9 @@ teamdynamix = ["py.typed"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
-pythonpath = ["src"]
-addopts = -q --cov=src/teamdynamix --cov-report=term-missing --cov-fail-under=80
+pythonpath = src
+addopts = -q --cov=teamdynamix --cov-report=term-missing --cov-fail-under=35
+testpaths = tests

--- a/src/py.typed
+++ b/src/py.typed
@@ -1,1 +1,0 @@
-# (Leave this file empty)

--- a/src/teamdynamix/__init__.py
+++ b/src/teamdynamix/__init__.py
@@ -1,7 +1,7 @@
 # src/teamdynamix/__init__.py
 from __future__ import annotations
 
-__version__ = "0.0.0-pre-alpha.11"
+__version__ = "0.0.0a11"
 
 # Exceptions (public)
 from .exceptions import (

--- a/src/teamdynamix/attributes.py
+++ b/src/teamdynamix/attributes.py
@@ -100,7 +100,7 @@ class AttributeChoice:
     """
     DTO representing an Attribute Choice (selectable options for an Attribute).
 
-    Fields align with the Postman/OpenAPI schema:
+    Fields align with the legacy Postman schema used for pre-alpha/11:
       ID, Name, IsActive, DateCreated, DateModified, Order
     """
 

--- a/src/teamdynamix/config.py
+++ b/src/teamdynamix/config.py
@@ -152,7 +152,7 @@ class Config:
             tenant=tenant,
             environment=environment,
             base_url_override=base_url_override,
-            auth_mode=auth_mode,  # type: ignore[arg-type]
+            auth_mode=auth_mode,
             beid=beid,
             webserviceskey=webserviceskey,
             username=username,

--- a/src/teamdynamix/projects.py
+++ b/src/teamdynamix/projects.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union, cast
 
 from .session import Session
 from .transport import PatchPayload
@@ -161,7 +161,7 @@ class Projects:
             payload = operations  # Transport converts dict -> patch list (replace ops)
         elif isinstance(operations, list):
             if all(isinstance(op, PatchPayload) for op in operations):
-                payload = [op.to_dict() for op in operations]
+                payload = [cast(PatchPayload, op).to_dict() for op in operations]
             elif all(isinstance(op, dict) for op in operations):
                 payload = operations
             else:

--- a/src/teamdynamix/py.typed
+++ b/src/teamdynamix/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561 typing support.

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,100 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+from teamdynamix.attributes import (
+    Attribute,
+    AttributeChoice,
+    Attributes,
+    _as_dict,
+    _as_list_of_dicts,
+)
+
+
+class StubResponse:
+    def __init__(self, data: Any) -> None:
+        self.data = data
+
+    def json(self) -> Any:
+        return self.data
+
+
+def _client(*responses: Any) -> tuple[Attributes, MagicMock]:
+    session = MagicMock()
+    session.request.side_effect = [StubResponse(response) for response in responses]
+    return Attributes(session), session
+
+
+def test_response_normalizers_reject_unexpected_shapes() -> None:
+    assert _as_list_of_dicts(None) == []
+    assert _as_list_of_dicts({"ID": 1}) == [{"ID": 1}]
+    assert _as_list_of_dicts([{"ID": 1}, "ignored", {"ID": 2}]) == [
+        {"ID": 1},
+        {"ID": 2},
+    ]
+    assert _as_list_of_dicts("unexpected") == []
+    assert _as_dict({"ID": 1}) == {"ID": 1}
+    assert _as_dict([]) is None
+
+
+def test_attribute_dtos_accept_common_id_casing() -> None:
+    assert Attribute.from_dict({"Id": 4, "Name": "Department"}).ID == 4
+    assert AttributeChoice.from_dict({"id": 8, "Name": "Finance", "Order": 2}) == (
+        AttributeChoice(ID=8, Name="Finance", Order=2)
+    )
+
+
+def test_attribute_listing_methods_use_legacy_paths_and_typed_wrappers() -> None:
+    client, session = _client(
+        [{"ID": 1, "Name": "Application"}],
+        [{"ID": 2, "Name": "Component"}],
+        [{"ID": 3, "Name": "All"}],
+    )
+
+    assert client.list_for_application_component(7, "/Tickets/")[0].ID == 1
+    assert client.list_for_component("/People/")[0].ID == 2
+    assert client.list_all()[0].ID == 3
+    assert [call.args[:2] for call in session.request.call_args_list] == [
+        ("GET", "/api/applications/7/attributes/Tickets"),
+        ("GET", "/api/attributes/People"),
+        ("GET", "/api/attributes"),
+    ]
+
+
+def test_attribute_choice_lifecycle_preserves_paths_payloads_and_copy_parameter() -> None:
+    client, session = _client(
+        [{"ID": 10, "Name": "Original"}],
+        {"ID": 11, "Name": "Copied"},
+        {"ID": 11, "Name": "Edited"},
+        None,
+    )
+
+    assert client.list_choices(5)[0].Name == "Original"
+    assert client.add_choice(5, {"Name": "Copied"}, copy_from_choice_id=10).ID == 11
+    assert client.edit_choice(5, 11, {"Name": "Edited"}).Name == "Edited"
+    assert client.delete_choice(5, 11) is True
+    assert session.request.call_args_list[1].kwargs == {
+        "params": {"copyFromChoiceId": "10"},
+        "json": {"Name": "Copied"},
+    }
+    assert session.request.call_args_list[2].args == (
+        "PUT",
+        "/api/attributes/5/choices/11",
+    )
+    assert session.request.call_args_list[3].args == (
+        "DELETE",
+        "/api/attributes/5/choices/11",
+    )
+
+
+def test_custom_attribute_filters_are_optional_and_use_vendor_parameter_names() -> None:
+    client, session = _client([{"ID": 21, "Name": "Filtered"}], [])
+
+    result = client.list_custom(component_id=1, associated_type_id=2, app_id=3)
+    empty = client.list_custom()
+
+    assert [attribute.ID for attribute in result] == [21]
+    assert empty == []
+    assert session.request.call_args_list[0].kwargs == {
+        "params": {"componentId": "1", "associatedTypeId": "2", "appId": "3"}
+    }
+    assert session.request.call_args_list[1].kwargs == {"params": None}

--- a/tests/test_core_boundaries.py
+++ b/tests/test_core_boundaries.py
@@ -1,0 +1,174 @@
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from teamdynamix import Config, Session
+from teamdynamix.auth import Auth
+from teamdynamix.exceptions import AuthError, HttpError, TdxRequestError, TdxTimeoutError
+from teamdynamix.transport import Transport
+
+
+class StubLogger:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def log(self, message: str, **_: Any) -> None:
+        self.messages.append(message)
+
+
+class StubResponse:
+    def __init__(self, *, status_code: int = 200, text: str = "", data: Any = None) -> None:
+        self.status_code = status_code
+        self.text = text
+        self._data = data
+
+    def json(self) -> Any:
+        return self._data
+
+
+def _config(log_dir: Path, *, auth_mode: str = "admin") -> Config:
+    values: dict[str, Any] = {
+        "tenant": "example.teamdynamix.com",
+        "environment": "TD",
+        "auth_mode": auth_mode,
+        "log_dir": str(log_dir),
+        "log_console": False,
+    }
+    if auth_mode == "admin":
+        values.update(beid="example-beid", webserviceskey="example-key")
+    else:
+        values.update(username="example-user", password="example-password")
+    return Config(**values)
+
+
+def test_transport_returns_successful_response_and_applies_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = StubResponse(status_code=200, data={"ok": True})
+    request = MagicMock(return_value=response)
+    monkeypatch.setattr(requests, "request", request)
+
+    transport = Transport(logger=StubLogger(), default_timeout=12)
+    result = transport.request("get", "https://example.test/api/items", params={"page": 2})
+
+    assert result is response
+    request.assert_called_once_with(
+        method="GET",
+        url="https://example.test/api/items",
+        headers=None,
+        params={"page": 2},
+        json=None,
+        data=None,
+        timeout=12,
+    )
+
+
+def test_transport_normalizes_patch_payload_and_content_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    request = MagicMock(return_value=StubResponse())
+    monkeypatch.setattr(requests, "request", request)
+
+    Transport(logger=StubLogger()).request(
+        "PATCH",
+        "https://example.test/api/items/1",
+        headers={"X-Test": "yes"},
+        json={"Name": "Updated"},
+    )
+
+    kwargs = request.call_args.kwargs
+    assert kwargs["json"] == [{"op": "replace", "path": "/Name", "value": "Updated"}]
+    assert kwargs["headers"] == {
+        "X-Test": "yes",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+
+
+def test_transport_raises_structured_http_error_without_logging_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        requests,
+        "request",
+        MagicMock(return_value=StubResponse(status_code=403, text="private details")),
+    )
+
+    with pytest.raises(HttpError) as raised:
+        Transport(logger=StubLogger()).request("POST", "https://example.test/api/items")
+
+    assert raised.value.status_code == 403
+    assert raised.value.method == "POST"
+    assert raised.value.response_text == "private details"
+    assert "private details" not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    ("request_error", "sdk_error"),
+    [
+        (requests.exceptions.Timeout("slow"), TdxTimeoutError),
+        (requests.exceptions.ConnectionError("offline"), TdxRequestError),
+    ],
+)
+def test_transport_translates_requests_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    request_error: requests.exceptions.RequestException,
+    sdk_error: type[Exception],
+) -> None:
+    logger = StubLogger()
+    monkeypatch.setattr(requests, "request", MagicMock(side_effect=request_error))
+
+    with pytest.raises(sdk_error):
+        Transport(logger=logger).request("GET", "https://example.test/api/items")
+
+    assert logger.messages
+
+
+def test_auth_builds_admin_request_and_caches_token(tmp_path: Path) -> None:
+    transport = MagicMock()
+    transport.request.return_value = StubResponse(text=" token-value ")
+    auth = Auth(config=_config(tmp_path), logger=StubLogger(), transport=transport)
+
+    assert auth.get_token() == "token-value"
+    assert auth.get_token() == "token-value"
+    assert auth.get_token(force_refresh=True) == "token-value"
+    assert transport.request.call_count == 2
+    transport.request.assert_called_with(
+        "POST",
+        "https://example.teamdynamix.com/TDWebApi/api/auth/loginadmin",
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        json={"BEID": "example-beid", "WebServicesKey": "example-key"},
+    )
+
+
+def test_auth_rejects_empty_user_token(tmp_path: Path) -> None:
+    transport = MagicMock()
+    transport.request.return_value = StubResponse(text="  ")
+    auth = Auth(
+        config=_config(tmp_path, auth_mode="user"),
+        logger=StubLogger(),
+        transport=transport,
+    )
+
+    with pytest.raises(AuthError, match="Empty token"):
+        auth.authenticate()
+
+
+def test_session_request_adds_base_url_and_lazy_auth_header(tmp_path: Path) -> None:
+    session = Session(_config(tmp_path))
+    session.auth = MagicMock()
+    session.auth.get_token.return_value = "cached-token"
+    session.transport = MagicMock()
+    expected = StubResponse(data={"ID": 1})
+    session.transport.request.return_value = expected
+
+    result = session.request("GET", "/api/items/1", params={"full": True})
+
+    assert result is expected
+    session.transport.request.assert_called_once_with(
+        method="GET",
+        url="https://example.teamdynamix.com/TDWebApi/api/items/1",
+        headers={"Authorization": "Bearer cached-token"},
+        params={"full": True},
+        json=None,
+        data=None,
+        timeout=None,
+    )

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,0 +1,90 @@
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+def test_built_distributions_include_metadata_and_support_import_smoke(tmp_path: Path) -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    build_root = tmp_path / "project"
+    build_root.mkdir()
+
+    for filename in ("pyproject.toml", "README.md", "LICENSE", "MANIFEST.in"):
+        shutil.copy2(project_root / filename, build_root / filename)
+    shutil.copytree(project_root / "src", build_root / "src")
+
+    dist_dir = tmp_path / "dist"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--sdist",
+            "--wheel",
+            "--no-isolation",
+            "--outdir",
+            str(dist_dir),
+        ],
+        cwd=build_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    wheel = next(dist_dir.glob("*.whl"))
+    sdist = next(dist_dir.glob("*.tar.gz"))
+    assert "0.0.0a11" in wheel.name
+
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+        metadata_name = next(name for name in names if name.endswith(".dist-info/METADATA"))
+        metadata = archive.read(metadata_name).decode()
+        assert "Version: 0.0.0a11" in metadata
+        assert "Requires-Dist: pandas>=2.0" in metadata
+        assert "teamdynamix/py.typed" in names
+        assert any(name.endswith(".dist-info/licenses/LICENSE") for name in names)
+
+    with tarfile.open(sdist) as archive:
+        names = archive.getnames()
+        assert any(name.endswith("/README.md") for name in names)
+        assert any(name.endswith("/LICENSE") for name in names)
+        assert any(name.endswith("/src/teamdynamix/py.typed") for name in names)
+
+    subprocess.run(
+        [sys.executable, "-m", "twine", "check", str(wheel), str(sdist)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    target = tmp_path / "installed"
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--no-deps", "--target", str(target), str(wheel)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(target)
+    env["PYTHONNOUSERSITE"] = "1"
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from pathlib import Path; "
+                "import teamdynamix, teamdynamix.tools; "
+                "root = Path(r'" + str(target) + "').resolve(); "
+                "assert Path(teamdynamix.__file__).resolve().is_relative_to(root); "
+                "assert teamdynamix.__version__ == '0.0.0a11'"
+            ),
+        ],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
Advances #16 without closing it; main promotion, tagging, and GitHub prerelease publication remain gated release actions.

Changes:
- Aligns installable package metadata, GitHub URLs, runtime dependencies, license, README, and PEP 561 marker
- Reclassifies live endpoint scripts and adds credential-free core, Attributes, and distribution tests
- Finalizes changelog, version summary, documentation links, Postman/OpenAPI boundary, and branch guidance

Version note: the project release label/tag remains 0.0.0-pre-alpha.11; Python package metadata and teamdynamix.__version__ use the required PEP 440 equivalent 0.0.0a11.

Validation:
- 19 pytest tests pass; 36.84% coverage against a 35% floor
- Ruff passes
- mypy passes for all 20 source modules
- wheel and sdist build, pass twine check, contain py.typed/LICENSE, and import teamdynamix plus teamdynamix.tools after installation
- relative Markdown links resolve