### PR TITLE
Complete #8: Centralize tools data helpers

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -67,5 +67,6 @@ scheduled for `pre-alpha/12`.
 ## Script Utilities (`teamdynamix.tools`)
 
 - [Tools overview](teamdynamix/tools/README.md)
+- [`data_utils`](teamdynamix/tools/data_utils.md)
 - [`csv_utils`](teamdynamix/tools/csv_utils.md)
 - [`sqlite_utils`](teamdynamix/tools/sqlite_utils.md)

--- a/docs/teamdynamix/tools/README.md
+++ b/docs/teamdynamix/tools/README.md
@@ -17,8 +17,15 @@ tasks that interact with TeamDynamix data.
 
 ## Modules
 
+- `data_utils` — Canonical path resolution and string normalization helpers
 - `csv_utils` — Load, query, search, and export CSV data for scripts
 - `sqlite_utils` — Temporary SQLite databases for batch and migration workflows
+
+Use the package-level imports for shared helpers:
+
+```python
+from teamdynamix.tools import clean_key, clean_str, resolve_data_path
+```
 
 ## When to use tools vs SDK clients
 

--- a/docs/teamdynamix/tools/csv_utils.md
+++ b/docs/teamdynamix/tools/csv_utils.md
@@ -278,12 +278,13 @@ to_csv(
 
 ------
 
-## Standard Data Path Resolution
+## Shared Data Path Resolution
 
-### `resolve_data_path(...)`
+Path resolution is provided by the canonical `data_utils` module rather than
+defined by `csv_utils`:
 
 ```python
-from teamdynamix.tools.csv_utils import resolve_data_path
+from teamdynamix.tools import resolve_data_path
 
 path = resolve_data_path("input.csv")
 ```
@@ -291,8 +292,8 @@ path = resolve_data_path("input.csv")
 Resolution order:
 
 1. Absolute path → used directly
-2. `base_dir` argument
-3. Environment variable (`TDX_DATA_DIR`)
+2. Existing candidate beneath `base_dir`
+3. Existing candidate beneath the environment directory (`TDX_DATA_DIR`)
 4. Current working directory
 
 This avoids hard-coding assumptions into scripts.

--- a/docs/teamdynamix/tools/data_utils.md
+++ b/docs/teamdynamix/tools/data_utils.md
@@ -1,0 +1,38 @@
+# `data_utils` Module
+
+**Module:** `teamdynamix.tools.data_utils`  
+**Purpose:** Shared local data-path and string-normalization helpers
+
+`data_utils` is the single canonical home for helpers shared by local script
+tooling. It does not import Session, authentication, transport, API clients, or
+other workflow components.
+
+## Public API
+
+### `resolve_data_path(path, base_dir=None, env_var="TDX_DATA_DIR")`
+
+Returns a `Path` using this precedence:
+
+1. An absolute input path is returned unchanged.
+2. An existing path beneath `base_dir` is returned.
+3. An existing path beneath the configured environment directory is returned.
+4. The path is returned beneath the current working directory, whether or not
+   it exists.
+
+```python
+from teamdynamix.tools import resolve_data_path
+
+input_path = resolve_data_path("input.csv")
+```
+
+The function resolves location only; callers decide whether a path must exist.
+
+### `clean_key(value)`
+
+Trims whitespace and removes one matching pair of surrounding single or double
+quotes.
+
+### `clean_str(value)`
+
+Maps `None` to an empty string, applies `clean_key` to strings, and converts
+other values with `str()`.

--- a/docs/teamdynamix/tools/sqlite_utils.md
+++ b/docs/teamdynamix/tools/sqlite_utils.md
@@ -85,15 +85,20 @@ This is intentionally **unopinionated**:
 - it works for typical scripts,
 - it is always overrideable.
 
-### `resolve_data_path(...)`
+### Shared path resolution
 
-The module includes a helper that resolves relative paths without hard-coding directory assumptions.
+SQLite functions use the canonical `teamdynamix.tools.data_utils.resolve_data_path`
+helper. User code should prefer the package-level import:
+
+```python
+from teamdynamix.tools import resolve_data_path
+```
 
 Resolution order:
 
 1. absolute path → used directly
-2. `base_dir` argument (if provided)
-3. environment variable (`TDX_DATA_DIR`)
+2. existing candidate beneath `base_dir` (if provided)
+3. existing candidate beneath the environment directory (`TDX_DATA_DIR`)
 4. current working directory
 
 ------

--- a/src/teamdynamix/tools/__init__.py
+++ b/src/teamdynamix/tools/__init__.py
@@ -13,6 +13,8 @@ automation workflows with predictable local data tooling.
 
 from __future__ import annotations
 
+from .data_utils import clean_key, clean_str, resolve_data_path
+
 # CSV utilities
 from .csv_utils import (
     DEFAULT_SEPARATOR_ORD,
@@ -22,7 +24,6 @@ from .csv_utils import (
     get_separator_ord,
     load_csv,
     reset_separator_default,
-    resolve_data_path as resolve_csv_data_path,
     set_separator,
     set_separator_ord,
 )
@@ -35,10 +36,13 @@ from .sqlite_utils import (
     archive_db_file,
     backup_db_file,
     create_db_file,
-    resolve_data_path as resolve_sqlite_data_path,
 )
 
 __all__ = [
+    # data_utils
+    "clean_key",
+    "clean_str",
+    "resolve_data_path",
     # csv_utils
     "DEFAULT_SEPARATOR_ORD",
     "CsvCellMatch",
@@ -49,7 +53,6 @@ __all__ = [
     "set_separator_ord",
     "reset_separator_default",
     "load_csv",
-    "resolve_csv_data_path",
     # sqlite_utils
     "DEFAULT_DB_PATH",
     "SqliteCellMatch",
@@ -57,5 +60,4 @@ __all__ = [
     "create_db_file",
     "backup_db_file",
     "archive_db_file",
-    "resolve_sqlite_data_path",
 ]

--- a/src/teamdynamix/tools/csv_utils.py
+++ b/src/teamdynamix/tools/csv_utils.py
@@ -22,7 +22,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Union
 
-import os
 import pandas as pd
 
 
@@ -116,41 +115,6 @@ def _maybe_log(logger: Any, message: str, *, level: int = 20, context: Optional[
         logger.log(message, level=level, context=context)
     except Exception:
         pass
-
-
-# ---------------------------------------------------------------------
-# Standard data path helpers (unopinionated)
-# ---------------------------------------------------------------------
-def resolve_data_path(
-    relative_or_absolute: Union[str, Path],
-    *,
-    base_dir: Optional[Union[str, Path]] = None,
-    env_var: str = "TDX_DATA_DIR",
-) -> Path:
-    """
-    Resolve a data path in an unopinionated way.
-
-    Rules:
-      - If input is absolute -> return as Path
-      - Else if base_dir provided -> base_dir / input
-      - Else if env var set (default: TDX_DATA_DIR) -> $TDX_DATA_DIR / input
-      - Else -> current working directory / input
-
-    This avoids hard-coding a data folder into the library while still supporting
-    standard script workflows.
-    """
-    p = Path(relative_or_absolute)
-    if p.is_absolute():
-        return p
-
-    if base_dir is not None:
-        return Path(base_dir) / p
-
-    env_base = os.getenv(env_var)
-    if env_base:
-        return Path(env_base) / p
-
-    return Path.cwd() / p
 
 
 # ---------------------------------------------------------------------

--- a/src/teamdynamix/tools/data_utils.py
+++ b/src/teamdynamix/tools/data_utils.py
@@ -1,0 +1,57 @@
+"""Shared, local-only data normalization and path helpers.
+
+This module has no dependency on TeamDynamix API clients, sessions, transport,
+or authentication. It centralizes small helpers used by script-oriented tools.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def resolve_data_path(
+    path: str | Path,
+    base_dir: str | Path | None = None,
+    env_var: str = "TDX_DATA_DIR",
+) -> Path:
+    """Resolve a data path using absolute, existing base/env, then cwd precedence.
+
+    Intermediate candidates under ``base_dir`` or ``env_var`` are selected only
+    when they already exist. The current-working-directory fallback is returned
+    whether or not it exists so callers retain control over validation.
+    """
+    candidate_path = Path(path)
+    if candidate_path.is_absolute():
+        return candidate_path
+
+    if base_dir is not None:
+        base_candidate = Path(base_dir) / candidate_path
+        if base_candidate.exists():
+            return base_candidate
+
+    env_base = os.environ.get(env_var)
+    if env_base:
+        env_candidate = Path(env_base) / candidate_path
+        if env_candidate.exists():
+            return env_candidate
+
+    return Path.cwd() / candidate_path
+
+
+def clean_key(value: str) -> str:
+    """Trim whitespace and one matching pair of surrounding quotes."""
+    cleaned = value.strip()
+    if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in {"'", '"'}:
+        cleaned = cleaned[1:-1].strip()
+    return cleaned
+
+
+def clean_str(value: Any) -> str:
+    """Normalize strings with :func:`clean_key`, map ``None`` to an empty string."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return clean_key(value)
+    return str(value)

--- a/src/teamdynamix/tools/sqlite_utils.py
+++ b/src/teamdynamix/tools/sqlite_utils.py
@@ -22,44 +22,13 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 
-
-# ---------------------------------------------------------------------
-# Standard data path resolution (unopinionated)
-# ---------------------------------------------------------------------
-def resolve_data_path(
-    relative_or_absolute: Union[str, Path],
-    *,
-    base_dir: Optional[Union[str, Path]] = None,
-    env_var: str = "TDX_DATA_DIR",
-) -> Path:
-    """
-    Resolve a data path in an unopinionated way.
-
-    Rules:
-      - If input is absolute -> return as Path
-      - Else if base_dir provided -> base_dir / input
-      - Else if env var set -> $TDX_DATA_DIR / input
-      - Else -> current working directory / input
-    """
-    p = Path(relative_or_absolute)
-    if p.is_absolute():
-        return p
-
-    if base_dir is not None:
-        return Path(base_dir) / p
-
-    env_base = os.getenv(env_var)
-    if env_base:
-        return Path(env_base) / p
-
-    return Path.cwd() / p
+from .data_utils import resolve_data_path
 
 
 def _maybe_log(logger: Any, message: str, *, level: int = 20, context: Optional[dict] = None) -> None:

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from teamdynamix.tools import clean_key, clean_str, resolve_data_path
+
+
+def test_resolve_data_path_returns_absolute_input_unchanged(tmp_path: Path) -> None:
+    absolute = tmp_path / "input.csv"
+
+    assert resolve_data_path(absolute) == absolute
+
+
+def test_resolve_data_path_prefers_existing_base_then_existing_environment(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base_dir = tmp_path / "base"
+    env_dir = tmp_path / "environment"
+    base_dir.mkdir()
+    env_dir.mkdir()
+    base_file = base_dir / "input.csv"
+    env_file = env_dir / "input.csv"
+    base_file.touch()
+    env_file.touch()
+    monkeypatch.setenv("TDX_DATA_DIR", str(env_dir))
+
+    assert resolve_data_path("input.csv", base_dir=base_dir) == base_file
+    base_file.unlink()
+    assert resolve_data_path("input.csv", base_dir=base_dir) == env_file
+
+
+def test_resolve_data_path_falls_back_to_cwd_without_requiring_existence(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TDX_DATA_DIR", raising=False)
+
+    assert resolve_data_path("future.csv") == tmp_path / "future.csv"
+
+
+def test_clean_key_and_clean_str_normalize_script_values() -> None:
+    assert clean_key("  'Project Managed'  ") == "Project Managed"
+    assert clean_key('"Hello"') == "Hello"
+    assert clean_key(" Hello ") == "Hello"
+    assert clean_str(None) == ""
+    assert clean_str("  'value' ") == "value"
+    assert clean_str(42) == "42"


### PR DESCRIPTION
Closes #8 and establishes the required foundation for #12 and #14.

- Adds canonical data_utils path and normalization helpers
- Removes duplicate path implementations
- Re-exports shared helpers from teamdynamix.tools
- Adds focused path-precedence and normalization tests
- Updates the tools documentation

Validation: 23 tests pass; Ruff and mypy pass; coverage 44.84%.