### PR TITLE
Complete #13: Add tools exception hierarchy

### DIFF
--- a/docs/teamdynamix/exceptions.md
+++ b/docs/teamdynamix/exceptions.md
@@ -45,6 +45,10 @@ from teamdynamix.exceptions import (
     HttpError,
     TdxTimeoutError,
     TdxRequestError,
+    ToolsError,
+    FingerprintMismatchError,
+    MigrationStateError,
+    DataPathError,
 )
 ```
 
@@ -75,6 +79,19 @@ You typically do not instantiate exceptions directly (except in tests). They are
 - Converting the exception to a string returns its explicit `message`, when set,
   or a concise `HTTP <status> <method> <URL>` summary. The response body is not
   included automatically, which avoids leaking sensitive API details into logs.
+
+### Local tools exceptions
+
+`ToolsError` is intentionally separate from `TdxError`. It represents local
+data, migration, and workflow-integrity failures rather than API or transport
+faults. All tools exceptions accept a message and optional structured `details`.
+
+| Exception                      | Intended use                                      |
+| ------------------------------ | ------------------------------------------------- |
+| `ToolsError`                   | Catch-all for local tools/workflow failures       |
+| `FingerprintMismatchError`     | Incompatible input or stored fingerprints         |
+| `MigrationStateError`          | Missing, unsafe, or incompatible migration state  |
+| `DataPathError`                | Required path resolution or validation failure    |
 
 ------
 
@@ -115,6 +132,13 @@ Specific subclasses include:
 - `HttpError` — HTTP non-success responses (structured dataclass)
 - `TdxTimeoutError` — request timeout
 - `TdxRequestError` — non-timeout transport errors (connection failures, etc.)
+
+The separate local-tools hierarchy includes:
+
+- `ToolsError` — base for tooling and workflow-integrity failures
+- `FingerprintMismatchError` — unsafe fingerprint mismatch
+- `MigrationStateError` — invalid migration/tracker state
+- `DataPathError` — required local path failure
 
 ### Common catching patterns
 

--- a/src/teamdynamix/__init__.py
+++ b/src/teamdynamix/__init__.py
@@ -11,6 +11,10 @@ from .exceptions import (
     HttpError,
     TdxTimeoutError,
     TdxRequestError,
+    ToolsError,
+    FingerprintMismatchError,
+    MigrationStateError,
+    DataPathError,
 )
 
 # Core
@@ -48,6 +52,10 @@ __all__ = [
     "HttpError",
     "TdxTimeoutError",
     "TdxRequestError",
+    "ToolsError",
+    "FingerprintMismatchError",
+    "MigrationStateError",
+    "DataPathError",
     # Core
     "Config",
     "Logger",

--- a/src/teamdynamix/exceptions.py
+++ b/src/teamdynamix/exceptions.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 class TdxError(Exception):
@@ -38,3 +39,23 @@ class TdxTimeoutError(TdxError):
 
 class TdxRequestError(TdxError):
     """Raised for non-timeout transport errors (connection errors, etc.)."""
+
+
+class ToolsError(Exception):
+    """Base exception for local tooling and workflow-integrity failures."""
+
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details = details
+
+
+class FingerprintMismatchError(ToolsError):
+    """Raised when incompatible data fingerprints make an operation unsafe."""
+
+
+class MigrationStateError(ToolsError):
+    """Raised when local migration or tracker state is missing or incompatible."""
+
+
+class DataPathError(ToolsError):
+    """Raised when a required local data path cannot be resolved or validated."""

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,11 @@
-from teamdynamix.exceptions import HttpError, TdxError
+from teamdynamix.exceptions import (
+    DataPathError,
+    FingerprintMismatchError,
+    HttpError,
+    MigrationStateError,
+    TdxError,
+    ToolsError,
+)
 
 
 def test_http_error_formats_request_context_without_response_body() -> None:
@@ -25,3 +32,18 @@ def test_http_error_preserves_explicit_message_and_exception_hierarchy() -> None
 
     assert str(error) == "Item was not found"
     assert isinstance(error, TdxError)
+
+
+def test_tools_errors_are_distinct_from_api_errors_and_preserve_details() -> None:
+    details = {"expected": "abc", "actual": "def"}
+    error = FingerprintMismatchError("Input fingerprint changed", details=details)
+
+    assert isinstance(error, ToolsError)
+    assert not isinstance(error, TdxError)
+    assert str(error) == "Input fingerprint changed"
+    assert error.details is details
+
+
+def test_tools_error_subclasses_share_the_local_workflow_boundary() -> None:
+    assert isinstance(MigrationStateError("Tracker missing"), ToolsError)
+    assert isinstance(DataPathError("Path missing"), ToolsError)


### PR DESCRIPTION
Closes #13.

- Adds ToolsError, FingerprintMismatchError, MigrationStateError, and DataPathError
- Keeps tools failures distinct from TdxError/API failures
- Supports inspectable structured details
- Exports and documents the complete hierarchy
- Adds focused hierarchy and details tests

Validation: 25 tests pass; Ruff and mypy pass; coverage 45.12%.