### PR TITLE
Complete #14: Lock the canonical tools path contract

### DIFF
--- a/docs/teamdynamix/tools/README.md
+++ b/docs/teamdynamix/tools/README.md
@@ -27,6 +27,15 @@ Use the package-level imports for shared helpers:
 from teamdynamix.tools import clean_key, clean_str, resolve_data_path
 ```
 
+## Shared helper import contract
+
+- Canonical implementation: `teamdynamix.tools.data_utils.resolve_data_path`
+- Preferred user import: `from teamdynamix.tools import resolve_data_path`
+- `csv_utils` and `sqlite_utils` do not define or re-export path helpers
+
+Keeping one implementation prevents behavior drift between CSV, SQLite, and
+future script utilities.
+
 ## When to use tools vs SDK clients
 
 Use `teamdynamix.tools` when:

--- a/docs/teamdynamix/tools/sqlite_utils.md
+++ b/docs/teamdynamix/tools/sqlite_utils.md
@@ -88,7 +88,8 @@ This is intentionally **unopinionated**:
 ### Shared path resolution
 
 SQLite functions use the canonical `teamdynamix.tools.data_utils.resolve_data_path`
-helper. User code should prefer the package-level import:
+helper internally through a private alias. `sqlite_utils` does not re-export the
+helper; user code should prefer the package-level import:
 
 ```python
 from teamdynamix.tools import resolve_data_path

--- a/src/teamdynamix/tools/sqlite_utils.py
+++ b/src/teamdynamix/tools/sqlite_utils.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 
-from .data_utils import resolve_data_path
+from .data_utils import resolve_data_path as _resolve_data_path
 
 
 def _maybe_log(logger: Any, message: str, *, level: int = 20, context: Optional[dict] = None) -> None:
@@ -92,7 +92,7 @@ def create_db_file(
     - Ensures parent directory exists.
     - Does not create tables; those are created when you initialize the tracker.
     """
-    p = resolve_data_path(db_path)
+    p = _resolve_data_path(db_path)
     p.parent.mkdir(parents=True, exist_ok=True)
 
     if p.exists() and overwrite:
@@ -121,11 +121,11 @@ def backup_db_file(
     Override:
       - pass backup_path for a custom destination.
     """
-    src = resolve_data_path(db_path)
+    src = _resolve_data_path(db_path)
     if not src.exists():
         raise FileNotFoundError(f"Database file does not exist: {src}")
 
-    dst = resolve_data_path(backup_path) if backup_path is not None else Path(str(src) + ".bak")
+    dst = _resolve_data_path(backup_path) if backup_path is not None else Path(str(src) + ".bak")
     dst.parent.mkdir(parents=True, exist_ok=True)
 
     _maybe_log(logger, "sqlite_utils.backup_db_file", context={"src": str(src), "dst": str(dst)})
@@ -147,7 +147,7 @@ def archive_db_file(
     Returns:
       (backup_path, new_db_path)
     """
-    src = resolve_data_path(db_path)
+    src = _resolve_data_path(db_path)
     bak = backup_db_file(src, backup_path=backup_path, logger=logger)
     new_db = create_db_file(src, overwrite=True, logger=logger)
     return (bak, new_db)
@@ -176,7 +176,7 @@ class SqliteTracker:
         *,
         logger: Any = None,
     ):
-        self.db_path = resolve_data_path(db_path)
+        self.db_path = _resolve_data_path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
         self._conn: Optional[sqlite3.Connection] = None

--- a/tests/test_tools_path_contract.py
+++ b/tests/test_tools_path_contract.py
@@ -1,0 +1,16 @@
+from teamdynamix import tools
+from teamdynamix.tools import csv_utils, data_utils, sqlite_utils
+
+
+def test_tools_package_exposes_only_the_canonical_public_path_helper() -> None:
+    assert tools.resolve_data_path is data_utils.resolve_data_path
+    assert "resolve_data_path" in tools.__all__
+    assert "clean_key" in tools.__all__
+    assert "clean_str" in tools.__all__
+
+
+def test_legacy_tools_modules_do_not_expose_path_helper_aliases() -> None:
+    assert not hasattr(csv_utils, "resolve_data_path")
+    assert not hasattr(sqlite_utils, "resolve_data_path")
+    assert not hasattr(tools, "resolve_csv_data_path")
+    assert not hasattr(tools, "resolve_sqlite_data_path")


### PR DESCRIPTION
Closes #14.

- Completes the repo-wide path-helper wiring sweep after #8
- Uses a private canonical import inside sqlite_utils so the legacy public module path is actually removed
- Documents canonical and preferred import paths
- Adds regression tests for package identity, exports, and absence of legacy aliases
- Confirms exactly one resolve_data_path definition and no old source/docs references

Validation: 27 tests pass; Ruff and mypy pass; coverage 45.12%.