### PR TITLE
Complete #12: Add neutral baseline script CLI utilities

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -68,5 +68,6 @@ scheduled for `pre-alpha/12`.
 
 - [Tools overview](teamdynamix/tools/README.md)
 - [`data_utils`](teamdynamix/tools/data_utils.md)
+- [`script_utils`](teamdynamix/tools/script_utils.md)
 - [`csv_utils`](teamdynamix/tools/csv_utils.md)
 - [`sqlite_utils`](teamdynamix/tools/sqlite_utils.md)

--- a/docs/teamdynamix/tools/README.md
+++ b/docs/teamdynamix/tools/README.md
@@ -18,6 +18,7 @@ tasks that interact with TeamDynamix data.
 ## Modules
 
 - `data_utils` — Canonical path resolution and string normalization helpers
+- `script_utils` — Reusable CLI flags and argument normalization without execution
 - `csv_utils` — Load, query, search, and export CSV data for scripts
 - `sqlite_utils` — Temporary SQLite databases for batch and migration workflows
 

--- a/docs/teamdynamix/tools/script_utils.md
+++ b/docs/teamdynamix/tools/script_utils.md
@@ -1,0 +1,43 @@
+# `script_utils` Module
+
+**Module:** `teamdynamix.tools.script_utils`  
+**Purpose:** Neutral, reusable command-line argument definitions and normalization
+
+`script_utils` standardizes the interface shared by script-oriented workflows.
+It parses values only. It does not load files, create databases, configure
+logging, authenticate, construct SDK sessions, or execute work.
+
+## `build_parser(...)`
+
+Creates an extensible `argparse.ArgumentParser`. Optional sections provide:
+
+- Mutually exclusive `--new`, `--overwrite`, and `--resume` flags
+- CSV, database, configuration, and log paths
+- Log level and console-output requests
+- Sleep throttling
+- A dry-run request
+
+```python
+from teamdynamix.tools.script_utils import build_parser
+
+parser = build_parser(
+    description="Import TeamDynamix records",
+    default_csv_path="input.csv",
+    default_db_path="tracker.db",
+)
+parser.add_argument("--application-id", type=int, required=True)
+args = parser.parse_args()
+```
+
+The calling script remains responsible for enforcing mode and dry-run behavior.
+
+## `get_mode(args)`
+
+Returns `"new"`, `"overwrite"`, or `"resume"`. When no mode flag is set, the
+deterministic default is `"new"`.
+
+## `normalize_paths(args, env_var="TDX_DATA_DIR")`
+
+Returns a `dict[str, Path]` for non-null `csv_path`, `db_path`, `config_path`,
+and `log_dir` attributes. Resolution delegates to the canonical
+`data_utils.resolve_data_path`; it does not require paths to exist.

--- a/src/teamdynamix/tools/__init__.py
+++ b/src/teamdynamix/tools/__init__.py
@@ -14,6 +14,7 @@ automation workflows with predictable local data tooling.
 from __future__ import annotations
 
 from .data_utils import clean_key, clean_str, resolve_data_path
+from .script_utils import build_parser, get_mode, normalize_paths
 
 # CSV utilities
 from .csv_utils import (
@@ -43,6 +44,10 @@ __all__ = [
     "clean_key",
     "clean_str",
     "resolve_data_path",
+    # script_utils
+    "build_parser",
+    "get_mode",
+    "normalize_paths",
     # csv_utils
     "DEFAULT_SEPARATOR_ORD",
     "CsvCellMatch",

--- a/src/teamdynamix/tools/script_utils.py
+++ b/src/teamdynamix/tools/script_utils.py
@@ -1,0 +1,127 @@
+"""Neutral command-line parsing helpers for script-oriented tooling.
+
+The module defines common arguments and normalizes parsed values. It does not
+load files, create databases, configure logging, authenticate, create SDK
+sessions, or execute workflow behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .data_utils import resolve_data_path
+
+
+def _path_default(value: str | Path | None) -> Path | None:
+    return None if value is None else Path(value)
+
+
+def build_parser(
+    *,
+    description: str,
+    default_csv_path: str | Path | None = None,
+    default_db_path: str | Path | None = None,
+    default_config_path: str | Path | None = None,
+    default_log_dir: str | Path | None = None,
+    default_sleep_seconds: float | None = None,
+    include_mode: bool = True,
+    include_paths: bool = True,
+    include_logging: bool = True,
+    include_sleep: bool = True,
+    include_dry_run: bool = True,
+) -> argparse.ArgumentParser:
+    """Build an extensible parser containing the requested baseline sections.
+
+    Parsing does not interpret workflow behavior. In particular, ``dry_run``
+    and the selected mode are values for the calling script to enforce.
+    """
+    parser = argparse.ArgumentParser(description=description)
+
+    if include_mode:
+        mode = parser.add_mutually_exclusive_group()
+        mode.add_argument("--new", action="store_true", help="Start a new workflow.")
+        mode.add_argument(
+            "--overwrite",
+            action="store_true",
+            help="Allow the calling script to replace prior workflow state.",
+        )
+        mode.add_argument(
+            "--resume",
+            action="store_true",
+            help="Resume workflow state according to the calling script.",
+        )
+
+    if include_paths:
+        parser.add_argument(
+            "--csv-path",
+            type=Path,
+            default=_path_default(default_csv_path),
+            help="CSV input path.",
+        )
+        parser.add_argument(
+            "--db-path",
+            type=Path,
+            default=_path_default(default_db_path),
+            help="Local tracker database path.",
+        )
+        parser.add_argument(
+            "--config-path",
+            type=Path,
+            default=_path_default(default_config_path),
+            help="Configuration file path.",
+        )
+
+    if include_logging:
+        parser.add_argument(
+            "--log-dir",
+            type=Path,
+            default=_path_default(default_log_dir),
+            help="Log output directory.",
+        )
+        parser.add_argument("--log-level", default="INFO", help="Requested log level.")
+        parser.add_argument(
+            "--log-console",
+            action="store_true",
+            default=False,
+            help="Request console log output.",
+        )
+
+    if include_sleep:
+        parser.add_argument(
+            "--sleep-seconds",
+            type=float,
+            default=default_sleep_seconds,
+            help="Requested delay between operations.",
+        )
+
+    if include_dry_run:
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Request a non-mutating run; enforcement belongs to the script.",
+        )
+
+    return parser
+
+
+def get_mode(args: argparse.Namespace) -> str:
+    """Return ``new``, ``overwrite``, or ``resume``; default to ``new``."""
+    for mode in ("new", "overwrite", "resume"):
+        if bool(getattr(args, mode, False)):
+            return mode
+    return "new"
+
+
+def normalize_paths(
+    args: argparse.Namespace,
+    *,
+    env_var: str = "TDX_DATA_DIR",
+) -> dict[str, Path]:
+    """Resolve non-``None`` path arguments without validating their existence."""
+    normalized: dict[str, Path] = {}
+    for name in ("csv_path", "db_path", "config_path", "log_dir"):
+        value = getattr(args, name, None)
+        if value is not None:
+            normalized[name] = resolve_data_path(value, env_var=env_var)
+    return normalized

--- a/tests/test_script_utils.py
+++ b/tests/test_script_utils.py
@@ -1,0 +1,97 @@
+import argparse
+from pathlib import Path
+
+import pytest
+
+from teamdynamix.tools.script_utils import build_parser, get_mode, normalize_paths
+
+
+def test_build_parser_includes_and_parses_the_full_baseline() -> None:
+    parser = build_parser(
+        description="Import records",
+        default_csv_path="input.csv",
+        default_db_path=Path("tracker.db"),
+        default_config_path="config.ini",
+        default_log_dir="logs",
+        default_sleep_seconds=0.5,
+    )
+    args = parser.parse_args(
+        [
+            "--resume",
+            "--csv-path",
+            "override.csv",
+            "--log-level",
+            "DEBUG",
+            "--log-console",
+            "--sleep-seconds",
+            "1.25",
+            "--dry-run",
+        ]
+    )
+
+    assert parser.description == "Import records"
+    assert args.resume is True
+    assert args.new is False
+    assert args.overwrite is False
+    assert args.csv_path == Path("override.csv")
+    assert args.db_path == Path("tracker.db")
+    assert args.config_path == Path("config.ini")
+    assert args.log_dir == Path("logs")
+    assert args.log_level == "DEBUG"
+    assert args.log_console is True
+    assert args.sleep_seconds == 1.25
+    assert args.dry_run is True
+
+
+def test_build_parser_sections_are_optional_and_parser_is_extensible() -> None:
+    parser = build_parser(
+        description="Minimal",
+        include_mode=False,
+        include_paths=False,
+        include_logging=False,
+        include_sleep=False,
+        include_dry_run=False,
+    )
+    parser.add_argument("--custom", required=True)
+
+    assert vars(parser.parse_args(["--custom", "value"])) == {"custom": "value"}
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ({}, "new"),
+        ({"new": True}, "new"),
+        ({"overwrite": True}, "overwrite"),
+        ({"resume": True}, "resume"),
+    ],
+)
+def test_get_mode_is_deterministic(values: dict[str, bool], expected: str) -> None:
+    assert get_mode(argparse.Namespace(**values)) == expected
+
+
+def test_mode_flags_are_mutually_exclusive() -> None:
+    parser = build_parser(description="Modes")
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--new", "--resume"])
+
+
+def test_normalize_paths_uses_data_utils_without_requiring_all_arguments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    csv_path = data_dir / "input.csv"
+    csv_path.touch()
+    monkeypatch.setenv("SCRIPT_DATA_DIR", str(data_dir))
+    monkeypatch.chdir(tmp_path)
+    args = argparse.Namespace(csv_path=Path("input.csv"), db_path=Path("future.db"))
+
+    normalized = normalize_paths(args, env_var="SCRIPT_DATA_DIR")
+
+    assert normalized == {
+        "csv_path": csv_path,
+        "db_path": tmp_path / "future.db",
+    }


### PR DESCRIPTION
Closes #12.

- Adds the extensible build_parser baseline with optional mode, path, logging, sleep, and dry-run sections
- Adds deterministic get_mode normalization
- Adds normalize_paths backed only by canonical data_utils path resolution
- Re-exports and documents the neutral helpers
- Adds full parser, toggle, mutual-exclusion, extension, mode, and path tests
- Contains no SDK Session, DB, CSV-loading, endpoint, or execution behavior

Validation: 35 tests pass; script_utils has 100% coverage; Ruff and mypy pass; total coverage 46.45%.