### PR TITLE
Update #16: Record promoted tools scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Python distribution metadata uses the PEP 440 equivalent `0.0.0a11`.
   application filters.
 - `AttributeChoice` and raw/typed Attributes response patterns.
 - `teamdynamix.tools` CSV and SQLite helpers for local automation scripts.
+- Canonical `data_utils` path and string-normalization helpers, exported through
+  `teamdynamix.tools`.
+- Neutral `script_utils` helpers for baseline CLI flags, deterministic mode
+  selection, and path normalization without workflow execution.
+- A distinct `ToolsError` hierarchy for local path, fingerprint, and migration
+  state failures.
 - Script-specific logger filename prefixes exposed through `Session`.
 - README, MIT license, PEP 561 marker, deterministic core tests, and built-wheel
   import smoke tests.
@@ -25,6 +31,8 @@ Python distribution metadata uses the PEP 440 equivalent `0.0.0a11`.
 - Reclassified live, state-changing endpoint scripts as manual examples.
 - Corrected package project URLs to GitHub and aligned release branch guidance
   with the project promotion model.
+- Removed duplicate and legacy `resolve_data_path` implementations and exports;
+  the canonical implementation now lives in `teamdynamix.tools.data_utils`.
 - Set an honest 35% coverage floor; the release suite currently exceeds it.
 
 ### Fixed

--- a/VERSION.md
+++ b/VERSION.md
@@ -20,8 +20,11 @@ planned for Pre-Alpha 12.
 
 - Expanded the `Attributes` client with attribute-choice lifecycle operations,
   custom-attribute discovery, raw response methods, and typed wrappers.
-- Added the first `teamdynamix.tools` package with pandas-backed CSV helpers and
-  SQLite tracking utilities for local scripts.
+- Added the first `teamdynamix.tools` package with pandas-backed CSV helpers,
+  SQLite tracking utilities, canonical data-path/string helpers, and neutral
+  command-line parser scaffolding for local scripts.
+- Added a distinct local-workflow exception hierarchy: `ToolsError`,
+  `FingerprintMismatchError`, `MigrationStateError`, and `DataPathError`.
 - Preserved the established `Session` / `Transport` / `Auth` architecture and
   centralized JSON Patch handling.
 - Added concise `HttpError` string output without automatically exposing
@@ -31,8 +34,8 @@ planned for Pre-Alpha 12.
 ## Release stabilization
 
 - Added deterministic tests for Session, Transport, Auth, Attributes, logging,
-  exceptions, and distribution artifacts; no live tenant credentials are
-  required.
+  exceptions, shared data helpers, script CLI parsing, tools import contracts,
+  and distribution artifacts; no live tenant credentials are required.
 - Reclassified state-changing endpoint exercises as manual examples.
 - Added build/install smoke coverage for both `teamdynamix` and
   `teamdynamix.tools`.
@@ -42,6 +45,8 @@ planned for Pre-Alpha 12.
   PEP 561 `py.typed` marker in the library namespace.
 - Reconciled documentation links, method names, branch flow, and the historical
   Postman/OpenAPI boundary.
+- Consolidated `resolve_data_path` into `teamdynamix.tools.data_utils`, removed
+  legacy module exports, and established a single package-level import contract.
 
 ## Known limitations
 


### PR DESCRIPTION
Updates #16 without closing it.

Reconciles VERSION.md and CHANGELOG.md after Issues #8, #12, #13, and #14 were explicitly promoted into pre-alpha/11. The release notes now include canonical data helpers, the local tools exception hierarchy, the neutral CLI parser, and expanded credential-free validation.

Validation: 35 tests pass; Ruff and mypy pass; coverage 46.45%; distribution build/import smoke remains green.