### PR TITLE
Complete #6: Centralize response normalization

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -32,6 +32,7 @@ scheduled for `pre-alpha/12`.
 - [`logger`](teamdynamix/logger.md)
 - [`event`](teamdynamix/events.md)
 - [`exceptions`](teamdynamix/exceptions.md)
+- [Internal response normalization](teamdynamix/response_normalization.md)
 
 ---
 

--- a/docs/teamdynamix/response_normalization.md
+++ b/docs/teamdynamix/response_normalization.md
@@ -1,0 +1,22 @@
+# Internal Response Normalization
+
+**Module:** `teamdynamix._response`  
+**API Surface:** Internal
+
+TeamDynamix endpoints may return an object, a list, an empty container, `null`,
+or occasionally mixed list entries. Client modules use three shared, stateless
+helpers to preserve consistent handling:
+
+- `as_list_of_dicts(data)`
+- `as_dict(data)`
+- `first_dict_or_none(data)`
+
+## Design decision: module functions instead of a mixin
+
+Normalization has no instance state and is not client-specific. Pure functions
+keep dependencies explicit at the import site, avoid inheritance and MRO
+concerns, and can be tested without constructing a Session or client. Client
+modules may import these helpers under their historical private names to avoid
+changing behavior while removing duplicate implementations.
+
+The module is internal and is not exported from `teamdynamix.__init__`.

--- a/src/teamdynamix/_response.py
+++ b/src/teamdynamix/_response.py
@@ -1,0 +1,40 @@
+"""Internal, stateless normalization for variable TeamDynamix JSON shapes.
+
+Pure module functions were selected instead of a mixin: normalization has no
+instance state, explicit imports make client dependencies visible, and avoiding
+inheritance prevents MRO/API-surface concerns as clients evolve.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def as_list_of_dicts(data: Any) -> list[dict[str, Any]]:
+    """Return dict payloads as a list and discard non-dict list entries."""
+    if not data:
+        return []
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    if isinstance(data, dict):
+        return [data]
+    return []
+
+
+def as_dict(data: Any) -> dict[str, Any] | None:
+    """Return a non-empty dict payload, otherwise ``None``."""
+    if not data:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def first_dict_or_none(data: Any) -> dict[str, Any] | None:
+    """Return a dict payload or the first list entry when that entry is a dict."""
+    if data is None:
+        return None
+    if isinstance(data, list):
+        if not data:
+            return None
+        first = data[0]
+        return first if isinstance(first, dict) else None
+    return data if isinstance(data, dict) else None

--- a/src/teamdynamix/accounts.py
+++ b/src/teamdynamix/accounts.py
@@ -6,35 +6,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from ._response import as_list_of_dicts as _as_list_of_dicts
+from ._response import first_dict_or_none as _first_or_none
 from .session import Session
-
-
-def _first_or_none(data: Any) -> Optional[Dict[str, Any]]:
-    """
-    TDX endpoints sometimes return:
-      - object (dict)
-      - list[dict]
-      - empty list []
-    Normalize to first dict or None.
-    """
-    if data is None:
-        return None
-    if isinstance(data, list):
-        if not data:
-            return None
-        first = data[0]
-        return first if isinstance(first, dict) else None
-    return data if isinstance(data, dict) else None
-
-
-def _as_list_of_dicts(data: Any) -> List[Dict[str, Any]]:
-    if not data:
-        return []
-    if isinstance(data, list):
-        return [x for x in data if isinstance(x, dict)]
-    if isinstance(data, dict):
-        return [data]
-    return []
 
 
 @dataclass(slots=True)

--- a/src/teamdynamix/applications.py
+++ b/src/teamdynamix/applications.py
@@ -6,17 +6,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from ._response import as_list_of_dicts as _as_list_of_dicts
 from .session import Session
-
-
-def _as_list_of_dicts(data: Any) -> List[Dict[str, Any]]:
-    if not data:
-        return []
-    if isinstance(data, list):
-        return [x for x in data if isinstance(x, dict)]
-    if isinstance(data, dict):
-        return [data]
-    return []
 
 
 @dataclass(slots=True)

--- a/src/teamdynamix/attributes.py
+++ b/src/teamdynamix/attributes.py
@@ -28,43 +28,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from ._response import as_dict as _as_dict
+from ._response import as_list_of_dicts as _as_list_of_dicts
 from .session import Session
-
-
-# -------------------------------------------------------------------
-# Response normalization helpers (consistent with pre-alpha10 style)
-# -------------------------------------------------------------------
-def _as_list_of_dicts(data: Any) -> List[Dict[str, Any]]:
-    """
-    Normalize an API response into list[dict].
-
-    Rules:
-      - None / [] / {} -> []
-      - dict -> [dict]
-      - list -> dict entries only
-      - anything else -> []
-    """
-    if not data:
-        return []
-    if isinstance(data, list):
-        return [x for x in data if isinstance(x, dict)]
-    if isinstance(data, dict):
-        return [data]
-    return []
-
-
-def _as_dict(data: Any) -> Optional[Dict[str, Any]]:
-    """
-    Normalize an API response into dict | None.
-
-    Rules:
-      - None / {} -> None
-      - dict -> dict
-      - anything else -> None
-    """
-    if not data:
-        return None
-    return data if isinstance(data, dict) else None
 
 
 # -------------------------------------------------------------------

--- a/src/teamdynamix/groups.py
+++ b/src/teamdynamix/groups.py
@@ -6,34 +6,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from ._response import as_list_of_dicts as _as_list_of_dicts
+from ._response import first_dict_or_none as _first_or_none
 from .session import Session
-
-
-def _first_or_none(data: Any) -> Optional[Dict[str, Any]]:
-    """
-    Normalize:
-      - dict -> dict
-      - list[dict] -> first dict
-      - []/None -> None
-    """
-    if data is None:
-        return None
-    if isinstance(data, list):
-        if not data:
-            return None
-        first = data[0]
-        return first if isinstance(first, dict) else None
-    return data if isinstance(data, dict) else None
-
-
-def _as_list_of_dicts(data: Any) -> List[Dict[str, Any]]:
-    if not data:
-        return []
-    if isinstance(data, list):
-        return [x for x in data if isinstance(x, dict)]
-    if isinstance(data, dict):
-        return [data]
-    return []
 
 
 @dataclass(slots=True)

--- a/src/teamdynamix/projects.py
+++ b/src/teamdynamix/projects.py
@@ -6,41 +6,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union, cast
 
+from ._response import as_dict as _as_dict
+from ._response import as_list_of_dicts as _as_list
 from .session import Session
 from .transport import PatchPayload
-
-
-def _as_list(data: Any) -> List[Dict[str, Any]]:
-    """
-    Normalize an API response into list[dict].
-
-    Rules:
-      - None / [] -> []
-      - dict -> [dict]
-      - list -> only dict entries (filters safely)
-      - anything else -> []
-    """
-    if not data:
-        return []
-    if isinstance(data, list):
-        return [x for x in data if isinstance(x, dict)]
-    if isinstance(data, dict):
-        return [data]
-    return []
-
-
-def _as_dict(data: Any) -> Optional[Dict[str, Any]]:
-    """
-    Normalize an API response into dict | None.
-
-    Rules:
-      - None / {} -> None
-      - dict -> dict
-      - anything else -> None
-    """
-    if not data:
-        return None
-    return data if isinstance(data, dict) else None
 
 
 @dataclass(slots=True)

--- a/src/teamdynamix/service_catalog.py
+++ b/src/teamdynamix/service_catalog.py
@@ -6,17 +6,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from ._response import as_list_of_dicts as _as_list_of_dicts
 from .session import Session
-
-
-def _as_list_of_dicts(data: Any) -> List[Dict[str, Any]]:
-    if not data:
-        return []
-    if isinstance(data, list):
-        return [x for x in data if isinstance(x, dict)]
-    if isinstance(data, dict):
-        return [data]
-    return []
 
 
 @dataclass(slots=True)

--- a/src/teamdynamix/tickets.py
+++ b/src/teamdynamix/tickets.py
@@ -6,36 +6,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
+from ._response import as_list_of_dicts as _as_list_of_dicts
+from ._response import first_dict_or_none as _first_or_none
 from .session import Session
 from .transport import PatchPayload  # exported publicly via __init__.py per your plan
-
-
-def _first_or_none(data: Any) -> Optional[Dict[str, Any]]:
-    """
-    TDX endpoints sometimes return either:
-      - an object (dict)
-      - a list of objects (list[dict])
-      - an empty list []
-    Normalize to "first dict or None".
-    """
-    if data is None:
-        return None
-    if isinstance(data, list):
-        if not data:
-            return None
-        first = data[0]
-        return first if isinstance(first, dict) else None
-    return data if isinstance(data, dict) else None
-
-
-def _as_list_of_dicts(data: Any) -> List[Dict[str, Any]]:
-    if not data:
-        return []
-    if isinstance(data, list):
-        return [x for x in data if isinstance(x, dict)]
-    if isinstance(data, dict):
-        return [data]
-    return []
 
 
 def _patch_ops_json(

--- a/tests/test_response_normalization.py
+++ b/tests/test_response_normalization.py
@@ -1,0 +1,41 @@
+import pytest
+
+from teamdynamix._response import as_dict, as_list_of_dicts, first_dict_or_none
+
+
+@pytest.mark.parametrize("value", [None, [], {}, "unexpected", 0, False])
+def test_as_list_of_dicts_normalizes_empty_and_non_container_values(value) -> None:
+    assert as_list_of_dicts(value) == []
+
+
+def test_as_list_of_dicts_wraps_dict_and_filters_mixed_lists() -> None:
+    payload = {"ID": 1}
+
+    assert as_list_of_dicts(payload) == [payload]
+    assert as_list_of_dicts([payload, "ignored", {"ID": 2}, None]) == [
+        payload,
+        {"ID": 2},
+    ]
+
+
+@pytest.mark.parametrize("value", [None, {}, [], "unexpected", 0, False])
+def test_as_dict_returns_none_for_empty_or_non_dict_values(value) -> None:
+    assert as_dict(value) is None
+
+
+def test_as_dict_preserves_non_empty_dict() -> None:
+    payload = {"ID": 1}
+
+    assert as_dict(payload) is payload
+
+
+def test_first_dict_or_none_preserves_legacy_first_entry_semantics() -> None:
+    empty: dict[str, object] = {}
+    first = {"ID": 1}
+
+    assert first_dict_or_none(empty) is empty
+    assert first_dict_or_none(first) is first
+    assert first_dict_or_none([first, {"ID": 2}]) is first
+    assert first_dict_or_none(["ignored", first]) is None
+    assert first_dict_or_none([]) is None
+    assert first_dict_or_none(None) is None


### PR DESCRIPTION
Centralizes duplicated API response normalization in a stateless internal module, documents the module-over-mixin decision, migrates all existing clients while preserving their private aliases and behavior, and adds focused edge-case tests.\n\nValidation: 50 tests pass; coverage 48.97%; Ruff and mypy pass.\n\nCloses #6