### PR TITLE
Complete #10: Persist fingerprints in SQLite

### DIFF
--- a/docs/teamdynamix/tools/sqlite_utils.md
+++ b/docs/teamdynamix/tools/sqlite_utils.md
@@ -167,6 +167,34 @@ Returns:
 
 ------
 
+## Fingerprint metadata
+
+`write_fingerprint_to_db(db, fingerprint)` persists a `FileFingerprint` in a
+dedicated `meta(key TEXT PRIMARY KEY, value TEXT NOT NULL)` table. The `db`
+argument may be a path or an existing `sqlite3.Connection`; writes are committed
+in either case, and caller-owned connections remain open.
+
+`read_fingerprint_from_db(db)` reconstructs the fingerprint when every required
+metadata key is present, or returns `None` for a missing or incomplete record.
+Tuple fields are encoded as JSON arrays so their order survives a round trip.
+
+```python
+from teamdynamix.tools import (
+    compute_fingerprint,
+    read_fingerprint_from_db,
+    write_fingerprint_to_db,
+)
+
+fingerprint = compute_fingerprint("input.csv")
+write_fingerprint_to_db("tracker.sqlite", fingerprint)
+assert read_fingerprint_from_db("tracker.sqlite") == fingerprint
+```
+
+These functions provide persistence only. Comparison and mismatch policy remain
+in `teamdynamix.tools.data_utils`.
+
+------
+
 ## `SqliteTracker` Class
 
 `SqliteTracker` is the main interface for:

--- a/src/teamdynamix/tools/__init__.py
+++ b/src/teamdynamix/tools/__init__.py
@@ -48,6 +48,8 @@ from .sqlite_utils import (
     archive_db_file,
     backup_db_file,
     create_db_file,
+    read_fingerprint_from_db,
+    write_fingerprint_to_db,
 )
 
 __all__ = [
@@ -83,4 +85,6 @@ __all__ = [
     "create_db_file",
     "backup_db_file",
     "archive_db_file",
+    "write_fingerprint_to_db",
+    "read_fingerprint_from_db",
 ]

--- a/src/teamdynamix/tools/sqlite_utils.py
+++ b/src/teamdynamix/tools/sqlite_utils.py
@@ -22,13 +22,112 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 
-from .data_utils import resolve_data_path as _resolve_data_path
+from .data_utils import FileFingerprint, resolve_data_path as _resolve_data_path
+
+
+_FINGERPRINT_META_KEYS = {
+    "fingerprint_algorithm",
+    "fingerprint_fields",
+    "fingerprint_version",
+    "fingerprint_path",
+    "fingerprint_file_sha256",
+    "fingerprint_mtime_ns",
+    "fingerprint_row_count",
+    "fingerprint_columns_json",
+}
+_REQUIRED_FINGERPRINT_META_KEYS = _FINGERPRINT_META_KEYS - {"fingerprint_version"}
+
+
+def _open_fingerprint_db(
+    db: str | Path | sqlite3.Connection,
+) -> tuple[sqlite3.Connection, bool]:
+    if isinstance(db, sqlite3.Connection):
+        return db, False
+    path = _resolve_data_path(db)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(str(path)), True
+
+
+def _ensure_meta_table(conn: sqlite3.Connection) -> None:
+    conn.execute('CREATE TABLE IF NOT EXISTS "meta" (key TEXT PRIMARY KEY, value TEXT NOT NULL)')
+
+
+def write_fingerprint_to_db(
+    db: str | Path | sqlite3.Connection,
+    fingerprint: FileFingerprint,
+) -> None:
+    """Persist a fingerprint in the database's key/value ``meta`` table."""
+    conn, owns_connection = _open_fingerprint_db(db)
+    try:
+        _ensure_meta_table(conn)
+        values = {
+            "fingerprint_algorithm": fingerprint.algorithm,
+            "fingerprint_fields": json.dumps(fingerprint.fingerprint_fields),
+            "fingerprint_path": fingerprint.path,
+            "fingerprint_file_sha256": fingerprint.file_sha256,
+            "fingerprint_mtime_ns": str(fingerprint.mtime_ns),
+            "fingerprint_row_count": str(fingerprint.row_count),
+            "fingerprint_columns_json": json.dumps(fingerprint.columns),
+        }
+        conn.executemany(
+            'INSERT INTO "meta" (key, value) VALUES (?, ?) '
+            'ON CONFLICT(key) DO UPDATE SET value = excluded.value',
+            values.items(),
+        )
+        if fingerprint.fingerprint_version is None:
+            conn.execute('DELETE FROM "meta" WHERE key = ?', ("fingerprint_version",))
+        else:
+            conn.execute(
+                'INSERT INTO "meta" (key, value) VALUES (?, ?) '
+                'ON CONFLICT(key) DO UPDATE SET value = excluded.value',
+                ("fingerprint_version", fingerprint.fingerprint_version),
+            )
+        conn.commit()
+    finally:
+        if owns_connection:
+            conn.close()
+
+
+def read_fingerprint_from_db(
+    db: str | Path | sqlite3.Connection,
+) -> FileFingerprint | None:
+    """Load a complete fingerprint from ``meta``, or return ``None`` if incomplete."""
+    conn, owns_connection = _open_fingerprint_db(db)
+    try:
+        _ensure_meta_table(conn)
+        rows = conn.execute(
+            f'SELECT key, value FROM "meta" WHERE key IN ({", ".join("?" for _ in _FINGERPRINT_META_KEYS)})',
+            tuple(_FINGERPRINT_META_KEYS),
+        ).fetchall()
+        values = {str(key): str(value) for key, value in rows}
+        if not _REQUIRED_FINGERPRINT_META_KEYS.issubset(values):
+            return None
+        fields = json.loads(values["fingerprint_fields"])
+        columns = json.loads(values["fingerprint_columns_json"])
+        if not isinstance(fields, list) or not all(isinstance(item, str) for item in fields):
+            raise ValueError("fingerprint_fields must be a JSON array of strings")
+        if not isinstance(columns, list) or not all(isinstance(item, str) for item in columns):
+            raise ValueError("fingerprint_columns_json must be a JSON array of strings")
+        return FileFingerprint(
+            path=values["fingerprint_path"],
+            algorithm=values["fingerprint_algorithm"],
+            file_sha256=values["fingerprint_file_sha256"],
+            mtime_ns=int(values["fingerprint_mtime_ns"]),
+            row_count=int(values["fingerprint_row_count"]),
+            columns=tuple(columns),
+            fingerprint_fields=tuple(fields),
+            fingerprint_version=values.get("fingerprint_version"),
+        )
+    finally:
+        if owns_connection:
+            conn.close()
 
 
 def _maybe_log(logger: Any, message: str, *, level: int = 20, context: Optional[dict] = None) -> None:

--- a/tests/test_sqlite_fingerprints.py
+++ b/tests/test_sqlite_fingerprints.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import replace
+from pathlib import Path
+
+from teamdynamix.tools import (
+    compute_fingerprint,
+    read_fingerprint_from_db,
+    write_fingerprint_to_db,
+)
+
+
+def _fingerprint(tmp_path: Path):
+    source = tmp_path / "records.csv"
+    source.write_text("id,name\n1,Ada\n", encoding="utf-8")
+    return compute_fingerprint(
+        source,
+        fingerprint_fields=("columns", "file_sha256", "fingerprint_version"),
+        fingerprint_version="1",
+    )
+
+
+def test_path_database_round_trip(tmp_path: Path) -> None:
+    fingerprint = _fingerprint(tmp_path)
+    db_path = tmp_path / "tracker.sqlite"
+
+    write_fingerprint_to_db(db_path, fingerprint)
+
+    assert read_fingerprint_from_db(db_path) == fingerprint
+    with sqlite3.connect(db_path) as conn:
+        schema = conn.execute("PRAGMA table_info('meta')").fetchall()
+    assert [(row[1], row[2], row[5]) for row in schema] == [
+        ("key", "TEXT", 1),
+        ("value", "TEXT", 0),
+    ]
+
+
+def test_existing_connection_is_committed_and_left_open(tmp_path: Path) -> None:
+    fingerprint = _fingerprint(tmp_path)
+    db_path = tmp_path / "tracker.sqlite"
+    conn = sqlite3.connect(db_path)
+    try:
+        write_fingerprint_to_db(conn, fingerprint)
+        assert read_fingerprint_from_db(conn) == fingerprint
+
+        with sqlite3.connect(db_path) as observer:
+            assert observer.execute('SELECT COUNT(*) FROM "meta"').fetchone()[0] == 8
+
+        assert conn.execute("SELECT 1").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_missing_or_partial_metadata_returns_none(tmp_path: Path) -> None:
+    db_path = tmp_path / "tracker.sqlite"
+
+    assert read_fingerprint_from_db(db_path) is None
+    with sqlite3.connect(db_path) as conn:
+        conn.execute('INSERT INTO "meta" (key, value) VALUES (?, ?)', ("fingerprint_path", "x"))
+        conn.commit()
+
+    assert read_fingerprint_from_db(db_path) is None
+
+
+def test_overwrite_removes_stale_optional_version(tmp_path: Path) -> None:
+    fingerprint = _fingerprint(tmp_path)
+    db_path = tmp_path / "tracker.sqlite"
+    write_fingerprint_to_db(db_path, fingerprint)
+
+    unversioned = replace(fingerprint, fingerprint_version=None)
+    write_fingerprint_to_db(db_path, unversioned)
+
+    assert read_fingerprint_from_db(db_path) == unversioned
+    with sqlite3.connect(db_path) as conn:
+        result = conn.execute(
+            'SELECT value FROM "meta" WHERE key = ?', ("fingerprint_version",)
+        ).fetchone()
+    assert result is None
+
+
+def test_rewrite_replaces_all_persisted_values(tmp_path: Path) -> None:
+    fingerprint = _fingerprint(tmp_path)
+    db_path = tmp_path / "tracker.sqlite"
+    write_fingerprint_to_db(db_path, fingerprint)
+    changed = replace(
+        fingerprint,
+        file_sha256="f" * 64,
+        row_count=99,
+        columns=("new", "shape"),
+        fingerprint_fields=("row_count", "columns"),
+        fingerprint_version="2",
+    )
+
+    write_fingerprint_to_db(db_path, changed)
+
+    assert read_fingerprint_from_db(db_path) == changed


### PR DESCRIPTION
Adds SQLite meta-table persistence for complete FileFingerprint round trips through either a database path or caller-owned sqlite3 connection. Writes commit without closing caller connections, optional versions are cleared safely, and incomplete metadata reads as None.\n\nValidation: 62 tests pass; coverage 51.81%; Ruff and mypy pass.\n\nCloses #10