### PR TITLE
Complete #11: Prepare migration trackers safely

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -72,3 +72,4 @@ scheduled for `pre-alpha/12`.
 - [`script_utils`](teamdynamix/tools/script_utils.md)
 - [`csv_utils`](teamdynamix/tools/csv_utils.md)
 - [`sqlite_utils`](teamdynamix/tools/sqlite_utils.md)
+- [`migration_utils`](teamdynamix/tools/migration_utils.md)

--- a/docs/teamdynamix/tools/migration_utils.md
+++ b/docs/teamdynamix/tools/migration_utils.md
@@ -1,0 +1,33 @@
+# `migration_utils` Module
+
+**Module:** `teamdynamix.tools.migration_utils`  
+**Purpose:** Prepare a fingerprint-bound SQLite tracker for local migration scripts
+
+`prepare_sqlite_tracker(mode, db_path, source_path, table, logger=None)` joins
+the lower-level CSV fingerprint and SQLite tracker primitives behind three
+explicit lifecycle modes:
+
+- `new` archives an existing database to its normal `.bak` path, creates a
+  fresh tracker, imports the supplied table, and stores the source fingerprint.
+- `overwrite` recreates the tracker without archiving, imports the supplied
+  table, and stores the source fingerprint.
+- `resume` requires an existing database and a complete stored fingerprint. It
+  verifies an exact fingerprint match and returns the existing tracker without
+  importing rows or changing progress.
+
+The table may be a `CsvTable` or any object implementing `columns()`,
+`row_count()`, and `get_row(index)`. Logging is optional and uses a simple
+callable accepting one message; the workflow has no Session, transport, or API
+client dependency.
+
+```python
+from teamdynamix.tools import load_csv, prepare_sqlite_tracker
+
+source = "people.csv"
+table = load_csv(source)
+tracker = prepare_sqlite_tracker("new", "people.sqlite", source, table)
+```
+
+Unsafe resume states fail closed: a missing database or fingerprint raises
+`MigrationStateError`, while changed source identity raises
+`FingerprintMismatchError` with field-level details.

--- a/src/teamdynamix/tools/__init__.py
+++ b/src/teamdynamix/tools/__init__.py
@@ -26,6 +26,7 @@ from .data_utils import (
     resolve_data_path,
 )
 from .script_utils import build_parser, get_mode, normalize_paths
+from .migration_utils import MigrationMode, MigrationTable, prepare_sqlite_tracker
 
 # CSV utilities
 from .csv_utils import (
@@ -68,6 +69,10 @@ __all__ = [
     "build_parser",
     "get_mode",
     "normalize_paths",
+    # migration_utils
+    "MigrationMode",
+    "MigrationTable",
+    "prepare_sqlite_tracker",
     # csv_utils
     "DEFAULT_SEPARATOR_ORD",
     "CsvCellMatch",

--- a/src/teamdynamix/tools/migration_utils.py
+++ b/src/teamdynamix/tools/migration_utils.py
@@ -1,0 +1,90 @@
+"""Local migration tracker preparation with explicit restart semantics."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from teamdynamix.exceptions import MigrationStateError
+
+from .data_utils import assert_fingerprint_match, compute_fingerprint, resolve_data_path
+from .sqlite_utils import (
+    SqliteTracker,
+    archive_db_file,
+    create_db_file,
+    read_fingerprint_from_db,
+    write_fingerprint_to_db,
+)
+
+MigrationMode = Literal["new", "overwrite", "resume"]
+
+
+class MigrationTable(Protocol):
+    """Minimum read-only table surface accepted by tracker preparation."""
+
+    def columns(self) -> Sequence[str]: ...
+
+    def row_count(self) -> int: ...
+
+    def get_row(self, index: int) -> Mapping[str, Any]: ...
+
+
+def _log(logger: Callable[[str], Any] | None, message: str) -> None:
+    if logger is not None:
+        logger(message)
+
+
+def _import_table(tracker: SqliteTracker, table: MigrationTable) -> int:
+    columns = tuple(str(column) for column in table.columns())
+    rows = (
+        tuple(table.get_row(index).get(column) for column in columns)
+        for index in range(table.row_count())
+    )
+    return tracker.import_rows(columns, rows, recreate=True)
+
+
+def prepare_sqlite_tracker(
+    mode: MigrationMode | str,
+    db_path: str | Path,
+    source_path: str | Path,
+    table: MigrationTable,
+    logger: Callable[[str], Any] | None = None,
+) -> SqliteTracker:
+    """Prepare a tracker for a new, overwritten, or safely resumed migration."""
+    if mode not in {"new", "overwrite", "resume"}:
+        raise MigrationStateError(
+            f"Unsupported migration mode: {mode}",
+            details={"mode": mode},
+        )
+
+    resolved_db = resolve_data_path(db_path)
+    current_fingerprint = compute_fingerprint(source_path)
+
+    if mode == "resume":
+        if not resolved_db.exists():
+            raise MigrationStateError(
+                f"Cannot resume: tracker database does not exist: {resolved_db}",
+                details={"db_path": str(resolved_db)},
+            )
+        stored_fingerprint = read_fingerprint_from_db(resolved_db)
+        if stored_fingerprint is None:
+            raise MigrationStateError(
+                "Cannot resume: tracker database has no complete source fingerprint",
+                details={"db_path": str(resolved_db)},
+            )
+        assert_fingerprint_match(stored_fingerprint, current_fingerprint)
+        _log(logger, f"Resuming existing SQLite tracker: {resolved_db}")
+        return SqliteTracker(resolved_db)
+
+    if mode == "new" and resolved_db.exists():
+        backup_path, _ = archive_db_file(resolved_db)
+        _log(logger, f"Archived existing SQLite tracker to: {backup_path}")
+    else:
+        create_db_file(resolved_db, overwrite=True)
+
+    tracker = SqliteTracker(resolved_db)
+    inserted = _import_table(tracker, table)
+    write_fingerprint_to_db(resolved_db, current_fingerprint)
+    _log(logger, f"Prepared SQLite tracker with {inserted} rows: {resolved_db}")
+    return tracker

--- a/tests/test_migration_utils.py
+++ b/tests/test_migration_utils.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from teamdynamix.exceptions import FingerprintMismatchError, MigrationStateError
+from teamdynamix.tools import prepare_sqlite_tracker
+
+
+@dataclass
+class FakeTable:
+    headers: tuple[str, ...]
+    rows: tuple[dict[str, Any], ...]
+
+    def columns(self) -> tuple[str, ...]:
+        return self.headers
+
+    def row_count(self) -> int:
+        return len(self.rows)
+
+    def get_row(self, index: int) -> dict[str, Any]:
+        return self.rows[index]
+
+
+def _source_and_table(tmp_path: Path) -> tuple[Path, FakeTable]:
+    source = tmp_path / "people.csv"
+    source.write_text("id,name\n1,Ada\n2,Grace\n", encoding="utf-8")
+    return source, FakeTable(
+        headers=("id", "name"),
+        rows=({"id": "1", "name": "Ada"}, {"id": "2", "name": "Grace"}),
+    )
+
+
+def test_new_creates_imported_fingerprinted_tracker(tmp_path: Path) -> None:
+    source, table = _source_and_table(tmp_path)
+    db_path = tmp_path / "tracker.sqlite"
+    messages: list[str] = []
+
+    tracker = prepare_sqlite_tracker("new", db_path, source, table, messages.append)
+    try:
+        assert tracker.row_count() == 2
+        assert tracker.columns() == ["id", "name"]
+        assert tracker.get_row(1) == {"id": "2", "name": "Grace"}
+    finally:
+        tracker.close()
+    assert any("Prepared SQLite tracker with 2 rows" in message for message in messages)
+
+
+def test_new_archives_an_existing_database(tmp_path: Path) -> None:
+    source, table = _source_and_table(tmp_path)
+    db_path = tmp_path / "tracker.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE legacy (value TEXT)")
+        conn.execute("INSERT INTO legacy VALUES ('preserved')")
+
+    tracker = prepare_sqlite_tracker("new", db_path, source, table)
+    tracker.close()
+
+    backup_path = Path(f"{db_path}.bak")
+    assert backup_path.exists()
+    with sqlite3.connect(backup_path) as conn:
+        assert conn.execute("SELECT value FROM legacy").fetchone()[0] == "preserved"
+
+
+def test_overwrite_recreates_without_archiving(tmp_path: Path) -> None:
+    source, table = _source_and_table(tmp_path)
+    db_path = tmp_path / "tracker.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE legacy (value TEXT)")
+
+    tracker = prepare_sqlite_tracker("overwrite", db_path, source, table)
+    try:
+        assert tracker.row_count() == 2
+    finally:
+        tracker.close()
+    assert not Path(f"{db_path}.bak").exists()
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='legacy'"
+        ).fetchone()[0] == 0
+
+
+def test_resume_preserves_existing_progress_without_reimport(tmp_path: Path) -> None:
+    source, table = _source_and_table(tmp_path)
+    db_path = tmp_path / "tracker.sqlite"
+    initial = prepare_sqlite_tracker("new", db_path, source, table)
+    rowid, _ = initial.pop()
+    assert rowid is not None
+    initial.mark_as_processed(rowid)
+    initial.close()
+
+    resumed = prepare_sqlite_tracker("resume", db_path, source, table)
+    try:
+        assert resumed.row_count() == 2
+        assert resumed.unprocessed_count() == 1
+    finally:
+        resumed.close()
+
+
+def test_resume_rejects_missing_database(tmp_path: Path) -> None:
+    source, table = _source_and_table(tmp_path)
+
+    with pytest.raises(MigrationStateError, match="database does not exist"):
+        prepare_sqlite_tracker("resume", tmp_path / "missing.sqlite", source, table)
+
+
+def test_resume_rejects_missing_fingerprint(tmp_path: Path) -> None:
+    source, table = _source_and_table(tmp_path)
+    db_path = tmp_path / "tracker.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE placeholder (value TEXT)")
+
+    with pytest.raises(MigrationStateError, match="no complete source fingerprint"):
+        prepare_sqlite_tracker("resume", db_path, source, table)
+
+
+def test_resume_rejects_changed_source(tmp_path: Path) -> None:
+    source, table = _source_and_table(tmp_path)
+    db_path = tmp_path / "tracker.sqlite"
+    tracker = prepare_sqlite_tracker("new", db_path, source, table)
+    tracker.close()
+    source.write_text("id,name\n1,Ada\n2,Grace Hopper\n", encoding="utf-8")
+
+    with pytest.raises(FingerprintMismatchError) as caught:
+        prepare_sqlite_tracker("resume", db_path, source, table)
+
+    assert caught.value.details is not None
+    assert "file_sha256" in caught.value.details["mismatches"]
+
+
+def test_invalid_mode_is_rejected(tmp_path: Path) -> None:
+    source, table = _source_and_table(tmp_path)
+
+    with pytest.raises(MigrationStateError, match="Unsupported migration mode"):
+        prepare_sqlite_tracker("continue", tmp_path / "tracker.sqlite", source, table)


### PR DESCRIPTION
Adds local-only migration tracker preparation with explicit new, overwrite, and fail-closed resume modes. Existing state is archived where required, source fingerprints bind tracker state, resume preserves processing progress without reimport, and the table dependency is a minimal protocol.\n\nValidation: 70 tests pass; coverage 60.08%; Ruff and mypy pass.\n\nCloses #11