### PR TITLE
Update #16: Record promoted migration scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Python distribution metadata uses the PEP 440 equivalent `0.0.0a11`.
   selection, and path normalization without workflow execution.
 - A distinct `ToolsError` hierarchy for local path, fingerprint, and migration
   state failures.
+- Immutable file fingerprints with configurable identity fields, structured
+  comparisons, and concise mismatch diagnostics.
+- SQLite fingerprint metadata persistence for paths and caller-owned
+  connections.
+- Fail-closed migration tracker preparation with explicit `new`, `overwrite`,
+  and `resume` modes.
 - Script-specific logger filename prefixes exposed through `Session`.
 - README, MIT license, PEP 561 marker, deterministic core tests, and built-wheel
   import smoke tests.
@@ -33,6 +39,8 @@ Python distribution metadata uses the PEP 440 equivalent `0.0.0a11`.
   with the project promotion model.
 - Removed duplicate and legacy `resolve_data_path` implementations and exports;
   the canonical implementation now lives in `teamdynamix.tools.data_utils`.
+- Centralized duplicated API response-shape normalization in a stateless
+  internal module shared by the existing client modules.
 - Set an honest 35% coverage floor; the release suite currently exceeds it.
 
 ### Fixed

--- a/VERSION.md
+++ b/VERSION.md
@@ -23,10 +23,13 @@ planned for Pre-Alpha 12.
 - Added the first `teamdynamix.tools` package with pandas-backed CSV helpers,
   SQLite tracking utilities, canonical data-path/string helpers, and neutral
   command-line parser scaffolding for local scripts.
+- Added immutable source-file fingerprints, field-level mismatch diagnostics,
+  SQLite fingerprint persistence, and fail-closed `new`, `overwrite`, and
+  `resume` migration tracker preparation.
 - Added a distinct local-workflow exception hierarchy: `ToolsError`,
   `FingerprintMismatchError`, `MigrationStateError`, and `DataPathError`.
 - Preserved the established `Session` / `Transport` / `Auth` architecture and
-  centralized JSON Patch handling.
+  centralized JSON Patch handling and API response normalization.
 - Added concise `HttpError` string output without automatically exposing
   response bodies.
 - Added script-specific logger filename prefixes through `Session`.
@@ -52,9 +55,9 @@ planned for Pre-Alpha 12.
 
 - API coverage remains intentionally limited to modules already present in the
   repository.
-- The `teamdynamix.tools` implementation is useful but has correctness,
-  scalability, state-model, and packaging boundaries scheduled for redesign in
-  Pre-Alpha 12.
+- Broader `teamdynamix.tools` scalability, state-model, and packaging boundaries
+  remain scheduled for redesign in Pre-Alpha 12; Pre-Alpha 11 now includes the
+  source-integrity and tracker-lifecycle safeguards required by local migrations.
 - Several existing client modules have only import-level or incidental test
   coverage; the configured 35% project floor records the current baseline
   rather than overstating maturity.


### PR DESCRIPTION
Updates VERSION.md and CHANGELOG.md to record the promoted response-normalization, fingerprinting, SQLite persistence, and migration tracker scope now included in pre-alpha/11. Issue #16 remains open for the final release gates.\n\nRefs #16